### PR TITLE
Support for Ingress Load Balancer Pools

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -109,6 +109,6 @@ resource "hcloud_firewall" "this" {
   }
 
   labels = {
-    "cluster" = var.cluster_name
+    cluster = var.cluster_name
   }
 }

--- a/ingress_nginx.tf
+++ b/ingress_nginx.tf
@@ -11,6 +11,18 @@ locals {
     var.ingress_nginx_replicas,
     local.worker_sum < 4 ? 2 : 3
   )
+
+  ingress_nginx_service_load_balancer_required = (
+    var.ingress_nginx_enabled &&
+    length(var.ingress_load_balancer_pools) == 0
+  )
+  ingress_nginx_service_type = (
+    local.ingress_nginx_service_load_balancer_required ?
+    "LoadBalancer" :
+    "NodePort"
+  )
+  ingress_nginx_service_node_port_http  = 30000
+  ingress_nginx_service_node_port_https = 30001
 }
 
 data "helm_template" "ingress_nginx" {
@@ -26,71 +38,6 @@ data "helm_template" "ingress_nginx" {
 
   set {
     name  = "controller.admissionWebhooks.certManager.enabled"
-    value = true
-  }
-  set {
-    name  = "controller.config.compute-full-forwarded-for"
-    value = true
-  }
-  set {
-    name  = "controller.config.proxy-real-ip-cidr"
-    value = hcloud_network_subnet.load_balancer.ip_range
-  }
-  set {
-    name  = "controller.config.use-proxy-protocol"
-    value = true
-  }
-
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/algorithm-type"
-    value = var.ingress_load_balancer_algorithm
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/disable-private-ingress"
-    value = true
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/disable-public-network"
-    value = !var.ingress_load_balancer_public_network_enabled
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/health-check-interval"
-    value = "3s"
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/health-check-retries"
-    value = 3
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/health-check-timeout"
-    value = "3s"
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/hostname"
-    value = local.ingress_load_balancer_hostname
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/ipv6-disabled"
-    value = false
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/location"
-    value = local.ingress_load_balancer_location
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/name"
-    value = local.ingress_load_balancer_name
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/type"
-    value = var.ingress_load_balancer_type
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/use-private-ip"
-    value = true
-  }
-  set {
-    name  = "controller.service.annotations.load-balancer\\.hetzner\\.cloud/uses-proxyprotocol"
     value = true
   }
 
@@ -117,11 +64,57 @@ data "helm_template" "ingress_nginx" {
             }
           }
         ]
-        watchIngressWithoutClass = true
+        enableTopologyAwareRouting = var.ingress_nginx_topology_aware_routing
+        watchIngressWithoutClass   = true
+        service = merge(
+          {
+            type                  = local.ingress_nginx_service_type
+            externalTrafficPolicy = var.ingress_nginx_service_external_traffic_policy
+          },
+          local.ingress_nginx_service_type == "NodePort" ?
+          {
+            nodePorts = {
+              http  = local.ingress_nginx_service_node_port_http,
+              https = local.ingress_nginx_service_node_port_https
+            }
+          } : {},
+          local.ingress_nginx_service_type == "LoadBalancer" ?
+          {
+            annotations = {
+              "load-balancer.hetzner.cloud/algorithm-type"          = var.ingress_load_balancer_algorithm
+              "load-balancer.hetzner.cloud/disable-private-ingress" = true
+              "load-balancer.hetzner.cloud/disable-public-network"  = !var.ingress_load_balancer_public_network_enabled
+              "load-balancer.hetzner.cloud/health-check-interval"   = "${var.ingress_load_balancer_health_check_interval}s"
+              "load-balancer.hetzner.cloud/health-check-retries"    = var.ingress_load_balancer_health_check_retries
+              "load-balancer.hetzner.cloud/health-check-timeout"    = "${var.ingress_load_balancer_health_check_timeout}s"
+              "load-balancer.hetzner.cloud/hostname"                = local.ingress_service_load_balancer_hostname
+              "load-balancer.hetzner.cloud/ipv6-disabled"           = false
+              "load-balancer.hetzner.cloud/location"                = local.ingress_service_load_balancer_location
+              "load-balancer.hetzner.cloud/name"                    = local.ingress_service_load_balancer_name
+              "load-balancer.hetzner.cloud/type"                    = var.ingress_load_balancer_type
+              "load-balancer.hetzner.cloud/use-private-ip"          = true
+              "load-balancer.hetzner.cloud/uses-proxyprotocol"      = true
+            }
+          } : {}
+        )
+        config = {
+          proxy-real-ip-cidr = (
+            var.ingress_nginx_service_external_traffic_policy == "Local" ?
+            hcloud_network_subnet.load_balancer.ip_range :
+            local.node_ipv4_cidr
+          )
+          compute-full-forwarded-for = true
+          use-proxy-protocol         = true
+        }
+        networkPolicy = {
+          enabled = true
+        }
       }
     }),
     yamlencode(var.ingress_nginx_helm_values)
   ]
+
+  depends_on = [hcloud_load_balancer_network.ingress]
 }
 
 locals {
@@ -133,6 +126,4 @@ locals {
       ${data.helm_template.ingress_nginx[0].manifest}
     EOF
   } : null
-
-  depends_on = [hcloud_load_balancer_network.ingress]
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -5,7 +5,11 @@ locals {
     length(local.cluster_autoscaler_nodepools) > 0 ? local.cluster_autoscaler_nodepools[0].location : null,
     local.control_plane_nodepools[0].location
   )
+}
 
+
+# Kubernetes API Load Balancer
+locals {
   kube_api_load_balancer_private_ipv4 = cidrhost(hcloud_network_subnet.load_balancer.ip_range, -2)
   kube_api_load_balancer_public_ipv4  = var.kube_api_load_balancer_enabled ? hcloud_load_balancer.kube_api[0].ipv4 : null
   kube_api_load_balancer_public_ipv6  = var.kube_api_load_balancer_enabled ? hcloud_load_balancer.kube_api[0].ipv6 : null
@@ -16,16 +20,8 @@ locals {
     var.kube_api_load_balancer_public_network_enabled,
     var.cluster_access == "public"
   )
-
-  ingress_load_balancer_private_ipv4 = cidrhost(hcloud_network_subnet.load_balancer.ip_range, -4)
-  ingress_load_balancer_public_ipv4  = var.ingress_nginx_enabled ? hcloud_load_balancer.ingress[0].ipv4 : null
-  ingress_load_balancer_public_ipv6  = var.ingress_nginx_enabled ? hcloud_load_balancer.ingress[0].ipv6 : null
-  ingress_load_balancer_hostname     = var.ingress_nginx_enabled ? "static.${join(".", reverse(split(".", local.ingress_load_balancer_public_ipv4)))}.clients.your-server.de" : ""
-  ingress_load_balancer_name         = "${var.cluster_name}-ingress"
-  ingress_load_balancer_location     = local.hcloud_load_balancer_location
 }
 
-# Kubernetes API Load Balancer
 resource "hcloud_load_balancer" "kube_api" {
   count = var.kube_api_load_balancer_enabled ? 1 : 0
 
@@ -59,15 +55,21 @@ resource "hcloud_load_balancer_target" "kube_api" {
   count = var.kube_api_load_balancer_enabled ? 1 : 0
 
   load_balancer_id = hcloud_load_balancer.kube_api[0].id
-  type             = "label_selector"
   use_private_ip   = true
 
+  type = "label_selector"
   label_selector = join(",",
     [
       "cluster=${var.cluster_name}",
       "role=control-plane"
     ]
   )
+
+  lifecycle {
+    replace_triggered_by = [
+      hcloud_load_balancer_network.kube_api
+    ]
+  }
 
   depends_on = [hcloud_load_balancer_network.kube_api]
 }
@@ -98,12 +100,22 @@ resource "hcloud_load_balancer_service" "kube_api" {
   depends_on = [hcloud_load_balancer_target.kube_api]
 }
 
-# Ingress Load Balancer
-resource "hcloud_load_balancer" "ingress" {
-  count = var.ingress_nginx_enabled ? 1 : 0
 
-  name               = local.ingress_load_balancer_name
-  location           = local.ingress_load_balancer_location
+# Ingress Service Load Balancer
+locals {
+  ingress_service_load_balancer_private_ipv4 = cidrhost(hcloud_network_subnet.load_balancer.ip_range, -4)
+  ingress_service_load_balancer_public_ipv4  = local.ingress_nginx_service_load_balancer_required ? hcloud_load_balancer.ingress[0].ipv4 : null
+  ingress_service_load_balancer_public_ipv6  = local.ingress_nginx_service_load_balancer_required ? hcloud_load_balancer.ingress[0].ipv6 : null
+  ingress_service_load_balancer_hostname     = local.ingress_nginx_service_load_balancer_required ? "static.${join(".", reverse(split(".", local.ingress_service_load_balancer_public_ipv4)))}.clients.your-server.de" : ""
+  ingress_service_load_balancer_name         = "${var.cluster_name}-ingress"
+  ingress_service_load_balancer_location     = local.hcloud_load_balancer_location
+}
+
+resource "hcloud_load_balancer" "ingress" {
+  count = local.ingress_nginx_service_load_balancer_required ? 1 : 0
+
+  name               = local.ingress_service_load_balancer_name
+  location           = local.ingress_service_load_balancer_location
   load_balancer_type = var.ingress_load_balancer_type
   delete_protection  = var.cluster_delete_protection
 
@@ -124,12 +136,171 @@ resource "hcloud_load_balancer" "ingress" {
 }
 
 resource "hcloud_load_balancer_network" "ingress" {
-  count = var.ingress_nginx_enabled ? 1 : 0
+  count = local.ingress_nginx_service_load_balancer_required ? 1 : 0
 
   load_balancer_id        = hcloud_load_balancer.ingress[0].id
   enable_public_interface = var.ingress_load_balancer_public_network_enabled
   subnet_id               = hcloud_network_subnet.load_balancer.id
-  ip                      = local.ingress_load_balancer_private_ipv4
+  ip                      = local.ingress_service_load_balancer_private_ipv4
 
   depends_on = [hcloud_network_subnet.load_balancer]
+}
+
+
+# Ingress Load Balancer Pools
+locals {
+  ingress_load_balancer_pools = [
+    for lp in var.ingress_load_balancer_pools : {
+      name               = lp.name
+      location           = lp.location
+      load_balancer_type = coalesce(lp.type, var.ingress_load_balancer_type)
+      labels = merge(
+        lp.labels,
+        { pool = lp.name }
+      )
+      count = lp.count
+      target_label_selector = length(lp.target_label_selector) > 0 ? lp.target_label_selector : concat(
+        [
+          for np in concat(
+            local.allow_scheduling_on_control_plane ? local.control_plane_nodepools : [],
+            local.worker_nodepools
+          ) : "cluster=${var.cluster_name},nodepool=${np.labels.nodepool}"
+          if(lp.local_traffic ? np.location == lp.location : true) &&
+          lookup(np.labels, "node.kubernetes.io/exclude-from-external-load-balancers", null) == null
+        ],
+        [
+          for np in local.cluster_autoscaler_nodepools :
+          "hcloud/node-group=${var.cluster_name}-${np.name}"
+          if(lp.local_traffic ? np.location == lp.location : true) &&
+          lookup(np.labels, "node.kubernetes.io/exclude-from-external-load-balancers", null) == null
+        ]
+      )
+      load_balancer_algorithm = coalesce(lp.load_balancer_algorithm, var.ingress_load_balancer_algorithm)
+      public_network_enabled  = coalesce(lp.public_network_enabled, var.ingress_load_balancer_public_network_enabled)
+    }
+  ]
+}
+
+resource "hcloud_load_balancer" "ingress_pool" {
+  for_each = merge([
+    for pool_index in range(length(local.ingress_load_balancer_pools)) : {
+      for lb_index in range(local.ingress_load_balancer_pools[pool_index].count) : "${var.cluster_name}-${local.ingress_load_balancer_pools[pool_index].name}-${lb_index + 1}" => {
+        location                = local.ingress_load_balancer_pools[pool_index].location,
+        load_balancer_type      = local.ingress_load_balancer_pools[pool_index].load_balancer_type,
+        load_balancer_algorithm = local.ingress_load_balancer_pools[pool_index].load_balancer_algorithm,
+        labels                  = local.ingress_load_balancer_pools[pool_index].labels
+      }
+    }
+  ]...)
+
+  name               = each.key
+  location           = each.value.location
+  load_balancer_type = each.value.load_balancer_type
+
+  algorithm {
+    type = each.value.load_balancer_algorithm
+  }
+
+  labels = merge(
+    each.value.labels,
+    {
+      cluster = var.cluster_name,
+      role    = "ingress"
+    }
+  )
+}
+
+resource "hcloud_load_balancer_network" "ingress_pool" {
+  for_each = merge([
+    for pool_index in range(length(local.ingress_load_balancer_pools)) : {
+      for lb_index in range(local.ingress_load_balancer_pools[pool_index].count) : "${var.cluster_name}-${local.ingress_load_balancer_pools[pool_index].name}-${lb_index + 1}" => {
+        public_network_enabled = local.ingress_load_balancer_pools[pool_index].public_network_enabled
+        ipv4_private = cidrhost(
+          hcloud_network_subnet.load_balancer.ip_range,
+          -5 - lb_index - (
+            pool_index > 0 ?
+            sum([for prior_pool_index in range(0, pool_index) : local.ingress_load_balancer_pools[prior_pool_index].count]) :
+            0
+          )
+        )
+      }
+    }
+  ]...)
+
+  load_balancer_id        = hcloud_load_balancer.ingress_pool[each.key].id
+  enable_public_interface = each.value.public_network_enabled
+  subnet_id               = hcloud_network_subnet.load_balancer.id
+  ip                      = each.value.ipv4_private
+}
+
+resource "hcloud_load_balancer_target" "ingress_pool" {
+  for_each = {
+    for entry in flatten([
+      for pool in local.ingress_load_balancer_pools : [
+        for lb_index in range(pool.count) : [
+          for target_index, target_label_selector in pool.target_label_selector : {
+            key = "${var.cluster_name}-${pool.name}-${lb_index + 1}-${target_index + 1}"
+            value = {
+              lb_name        = "${var.cluster_name}-${pool.name}-${lb_index + 1}"
+              label_selector = target_label_selector
+            }
+          }
+        ]
+      ]
+    ]) : entry.key => entry.value
+  }
+
+  load_balancer_id = hcloud_load_balancer.ingress_pool[each.value.lb_name].id
+  use_private_ip   = true
+
+  type           = "label_selector"
+  label_selector = each.value.label_selector
+
+  lifecycle {
+    replace_triggered_by = [
+      # Can't reference a specific network, only count.index or each.key are supported here
+      hcloud_load_balancer_network.ingress_pool
+    ]
+  }
+
+  depends_on = [hcloud_load_balancer_network.ingress_pool]
+}
+
+resource "hcloud_load_balancer_service" "ingress_pool" {
+  for_each = {
+    for entry in flatten([
+      for pool in local.ingress_load_balancer_pools : [
+        for lb_index in range(pool.count) : [
+          for protocol in ["http", "https"] : {
+            key = "${var.cluster_name}-${pool.name}-${lb_index + 1}-${protocol}"
+            value = {
+              lb_name     = "${var.cluster_name}-${pool.name}-${lb_index + 1}"
+              listen_port = protocol == "http" ? 80 : 443
+              destination_port = (
+                protocol == "http" ?
+                local.ingress_nginx_service_node_port_http :
+                local.ingress_nginx_service_node_port_https
+              )
+            }
+          }
+        ]
+      ]
+    ]) : entry.key => entry.value
+  }
+
+  load_balancer_id = hcloud_load_balancer.ingress_pool[each.value.lb_name].id
+  listen_port      = each.value.listen_port
+  destination_port = each.value.destination_port
+  protocol         = "tcp"
+  proxyprotocol    = true
+
+  health_check {
+    protocol = "tcp"
+    port     = each.value.destination_port
+    interval = var.ingress_load_balancer_health_check_interval
+    timeout  = var.ingress_load_balancer_health_check_timeout
+    retries  = var.ingress_load_balancer_health_check_retries
+  }
+
+  depends_on = [hcloud_load_balancer_target.ingress_pool]
 }

--- a/server.tf
+++ b/server.tf
@@ -2,7 +2,6 @@ resource "hcloud_server" "control_plane" {
   for_each = merge([
     for np_index in range(length(local.control_plane_nodepools)) : {
       for cp_index in range(local.control_plane_nodepools[np_index].count) : "${var.cluster_name}-${local.control_plane_nodepools[np_index].name}-${cp_index + 1}" => {
-        name               = "${var.cluster_name}-${local.control_plane_nodepools[np_index].name}-${cp_index + 1}",
         server_type        = local.control_plane_nodepools[np_index].server_type,
         location           = local.control_plane_nodepools[np_index].location,
         backups            = local.control_plane_nodepools[np_index].backups,
@@ -18,7 +17,7 @@ resource "hcloud_server" "control_plane" {
     }
   ]...)
 
-  name                     = each.value.name
+  name                     = each.key
   image                    = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.arm64[0].id : data.hcloud_image.amd64[0].id
   server_type              = each.value.server_type
   location                 = each.value.location
@@ -30,10 +29,13 @@ resource "hcloud_server" "control_plane" {
   delete_protection        = var.cluster_delete_protection
   rebuild_protection       = var.cluster_delete_protection
 
-  labels = merge({
-    cluster = var.cluster_name,
-    role    = "control-plane"
-  }, each.value.labels)
+  labels = merge(
+    each.value.labels,
+    {
+      cluster = var.cluster_name,
+      role    = "control-plane"
+    }
+  )
 
   firewall_ids = [
     hcloud_firewall.this.id
@@ -68,7 +70,6 @@ resource "hcloud_server" "worker" {
   for_each = merge([
     for np_index in range(length(local.worker_nodepools)) : {
       for wkr_index in range(local.worker_nodepools[np_index].count) : "${var.cluster_name}-${local.worker_nodepools[np_index].name}-${wkr_index + 1}" => {
-        name               = "${var.cluster_name}-${local.worker_nodepools[np_index].name}-${wkr_index + 1}",
         server_type        = local.worker_nodepools[np_index].server_type,
         location           = local.worker_nodepools[np_index].location,
         backups            = local.worker_nodepools[np_index].backups,
@@ -81,7 +82,7 @@ resource "hcloud_server" "worker" {
     }
   ]...)
 
-  name                     = each.value.name
+  name                     = each.key
   image                    = substr(each.value.server_type, 0, 3) == "cax" ? data.hcloud_image.arm64[0].id : data.hcloud_image.amd64[0].id
   server_type              = each.value.server_type
   location                 = each.value.location
@@ -93,10 +94,13 @@ resource "hcloud_server" "worker" {
   delete_protection        = var.cluster_delete_protection
   rebuild_protection       = var.cluster_delete_protection
 
-  labels = merge({
-    cluster = var.cluster_name,
-    role    = "worker"
-  }, each.value.labels)
+  labels = merge(
+    each.value.labels,
+    {
+      cluster = var.cluster_name,
+      role    = "worker"
+    }
+  )
 
   firewall_ids = [
     hcloud_firewall.this.id


### PR DESCRIPTION
This PR adds support for ingress load balancer pools in the Terraform configuration, replacing the default load balancer with geo-redundant pools for improved high availability and scalability. It also enables local traffic optimization and optionally supports topology-aware routing for efficient traffic handling.