### PR TITLE
Add bind-address to controller-manager extraArgs

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -246,7 +246,10 @@ locals {
           )
         }
         controllerManager = {
-          extraArgs = { "cloud-provider" = "external" }
+          extraArgs = {
+            "cloud-provider" = "external"
+            "bind-address" = "0.0.0.0"
+          }
         }
         discovery = {
           enabled = true,


### PR DESCRIPTION
Fixes #53 
Needed to scrape metrics from kube-controller-manager without applying a config patch.