### PR TITLE
Upgrade to Talos 1.8 and Kubernetes 1.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ The [Talos Terraform Provider](https://registry.terraform.io/providers/siderolab
 | Hcloud K8s |  K8s  | Talos | Talos CCM | Hcloud CCM | Hcloud CSI | Long-horn | Cilium | Ingress NGINX | Cert Mgr. | Auto-scaler |
 | :--------: | :---: | :---: | :-------: | :--------: | :--------: | :-------: | :----: | :-----------: | :-------: | :---------: |
 |  (**2**)   | 1.32  |  1.9  |    1.9    |    1.23    |     ?      |     ?     |  1.17  |     4.12      |     ?     |    9.45     |
-|  (**1**)   | 1.31  |  1.8  |    1.8    |    1.21    |    2.10    |    1.8    |  1.17  |     4.12      |   1.15    |    9.38     |
+|   **1**    | 1.31  |  1.8  |    1.8    |    1.21    |    2.10    |    1.8    |  1.17  |     4.12      |   1.15    |    9.38     |
 |   **0**    | 1.30  |  1.7  |    1.6    |    1.20    |    2.9     |   1.7.1   |  1.16  |    4.10.1     |   1.14    |    9.37     |
 
 In this module, upgrades are conducted with care and conservatism. You will consistently receive the most tested and compatible releases of all components, avoiding the latest untested or incompatible releases that could disrupt your cluster.
@@ -633,8 +633,9 @@ In this module, upgrades are conducted with care and conservatism. You will cons
 
 <!-- Roadmap -->
 ## :compass: Roadmap
-
-* [ ] **Upgrade to Talos 1.8 and Kubernetes 1.31**<br>
+* [ ] **Upgrade to Talos 1.9 and Kubernetes 1.32**<br>
+      Once all components have compatible versions, the upgrade can be performed.
+* [x] **Upgrade to Talos 1.8 and Kubernetes 1.31**<br>
       Once all components have compatible versions, the upgrade can be performed.
 * [ ] **Integrate native IPv6 for pod traffic**<br>
       Completion requires Hetzner's addition of IPv6 support to cloud networks, expected at the beginning of 2025 as announced at Hetzner Summit 2024.

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -133,8 +133,7 @@ locals {
           extraKernelArgs = var.talos_extra_kernel_args
         }
         nodeLabels = merge(
-          #local.allow_scheduling_on_control_plane ? { "node.kubernetes.io/exclude-from-external-load-balancers" = { "$patch" = "delete" } } : {},
-          local.allow_scheduling_on_control_plane ? {} : { "node.kubernetes.io/exclude-from-external-load-balancers" = "" },
+          local.allow_scheduling_on_control_plane ? { "node.kubernetes.io/exclude-from-external-load-balancers" = { "$patch" = "delete" } } : {},
           local.control_plane_nodepools_map[node.labels.nodepool].labels
         )
         nodeAnnotations = local.control_plane_nodepools_map[node.labels.nodepool].annotations

--- a/variables.tf
+++ b/variables.tf
@@ -493,7 +493,7 @@ variable "cluster_autoscaler_config_patches" {
 # Talos
 variable "talos_version" {
   type        = string
-  default     = "v1.7.7"
+  default     = "v1.8.4"
   description = "Specifies the version of Talos to be used in generated machine configurations."
 }
 
@@ -731,7 +731,7 @@ variable "talos_backup_schedule" {
 # Kubernetes
 variable "kubernetes_version" {
   type        = string
-  default     = "v1.30.5"
+  default     = "v1.31.4"
   description = "Specifies the Kubernetes version to deploy."
 }
 


### PR DESCRIPTION
Upgrade to Talos `v1.8.4` and Kubernetes `v1.31.4`

Note: As of Talos version `1.8.*`, the etcd cluster requires additional time to fully bootstrap compared to version `1.7.*`, though it has consistently succeeded in all tests.