### PR TITLE
feat: add Talos logging destinations to allow sending logs to collectors

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -231,6 +231,9 @@ locals {
         time = {
           servers = var.talos_time_servers
         }
+        logging = {
+          destinations = var.talos_service_log_destinations
+        }
       }
       cluster = {
         allowSchedulingOnControlPlanes = local.allow_scheduling_on_control_plane
@@ -372,6 +375,9 @@ locals {
         time = {
           servers = var.talos_time_servers
         }
+        logging = {
+          destinations = var.talos_service_log_destinations
+        }
       }
       cluster = {
         network = {
@@ -475,6 +481,9 @@ locals {
         }
         time = {
           servers = var.talos_time_servers
+        }
+        logging = {
+          destinations = var.talos_service_log_destinations
         }
       }
       cluster = {

--- a/variables.tf
+++ b/variables.tf
@@ -657,6 +657,15 @@ variable "talos_registries" {
   EOF
 }
 
+variable "talos_service_log_destinations" {
+  description = "List of objects defining remote destinations for Talos service logs."
+  type = list(object({
+    endpoint  = string
+    format    = optional(string, "json_lines")
+    extraTags = optional(map(string), {})
+  }))
+  default = []
+}
 
 # Talos Backup
 variable "talos_backup_version" {


### PR DESCRIPTION
As a user of your (fantastic!) Terraform module, I want to be able to send Talos logs to a log collector.

For [kernel logs](https://www.talos.dev/v1.9/talos-guides/configuration/logging/#kernel-logs) its already possible to just configure something like:

```hcl
# 127.0.0.1:6050 would be for example Vector running in hostNetwork on port 6050
talos_extra_kernel_args = ["talos.logging.kernel=tcp://127.0.0.1:6050/"]
```

But for the [service logs](https://www.talos.dev/v1.9/talos-guides/configuration/logging/#service-logs) there is currently no way to configure the `logging` part of the machine configuration.

This change adds this config as control plane, worker and autoscaler talos config patches. The user can then set something like this:

```hcl
  talos_service_log_destinations = [
    {
      endpoint = "tcp://127.0.0.1:6051" # Forward to Vector on 6051
    }
  ]
```

Then these service logs will also be forwarded to the users log collector of choice.