### PR TITLE
fix: Talos health checks for Kubernetes v1.32+

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ talos_kubernetes_discovery_service_enabled = false
 talos_siderolabs_discovery_service_enabled = true
 ```
 
-> :no_entry_sign: Enabling **both** discovery services at the same time is not supported and will trigger a validation error.
+> :no_entry_sign: Enabling **both** discovery services at the same time is not supported.
 
 #### :rocket: Upgrading to Kubernetes 1.32
 

--- a/README.md
+++ b/README.md
@@ -600,6 +600,41 @@ talos_backup_schedule = "0 * * * *"
 To recover from a snapshot, please refer to the Talos Disaster Recovery section in the [Documentation](https://www.talos.dev/latest/advanced/disaster-recovery/#recovery).
 </details>
 
+<!-- Talos Discovery Service -->
+<details>
+<summary><b>Talos Node Discovery Service</b></summary>
+
+Talos supports two node discovery mechanisms:
+
+- **SideroLabs Discovery Service** (default): A public, external registry that functions even when Kubernetes is unavailable.
+- **Kubernetes Registry**: Uses Kubernetes Node metadata stored in etcd.
+
+> :warning: **Important:** As of Kubernetes **v1.32**, the Kubernetes registry is **no longer compatible by default** due to the `AuthorizeNodeWithSelectors` feature gate, which restricts access to Node metadata.  
+> Attempting to use Kubernetes-based discovery with Kubernetes ≥ v1.32 **will result in broken discovery behavior** (e.g., `talosctl get members` may fail or show incomplete data).
+
+#### :white_check_mark: Recommended configuration (v1.32+)
+
+Starting with **module version `v2.0.0`**, Kubernetes-based discovery is **disabled by default**, and you should rely on the Sidero Labs discovery service instead.
+
+#### :hammer_and_wrench: Example Configuration
+
+```hcl
+# Disable Kubernetes-based discovery (deprecated in Kubernetes >= 1.32)
+talos_kubernetes_discovery_service_enabled = false
+
+# Enable the external SideroLabs discovery service (default)
+talos_siderolabs_discovery_service_enabled = true
+```
+
+> :no_entry_sign: Enabling **both** discovery services at the same time is not supported and will trigger a validation error.
+
+#### :rocket: Upgrading to Kubernetes 1.32
+
+If you are upgrading from Kubernetes v1.31 to v1.32 or later, ensure you **disable the Kubernetes registry** to avoid issues with node discovery.
+
+For more details, refer to the [official Talos discovery guide](https://www.talos.dev/v1.9/talos-guides/discovery/).
+</details>
+
 <!-- Lifecycle -->
 ## :recycle: Lifecycle
 The [Talos Terraform Provider](https://registry.terraform.io/providers/siderolabs/talos) does not support declarative upgrades of Talos or Kubernetes versions. This module compensates for these limitations using `talosctl` to implement the required functionalities. Any minor or major upgrades to Talos and Kubernetes will result in a major version change of this module. Please be aware that downgrades are typically neither supported nor tested.

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ To recover from a snapshot, please refer to the Talos Disaster Recovery section 
 
 Talos supports two node discovery mechanisms:
 
-- **SideroLabs Discovery Service** (default): A public, external registry that functions even when Kubernetes is unavailable.
+- **Sidero Labs Discovery Service** (default): A public, external registry that functions even when Kubernetes is unavailable.
 - **Kubernetes Registry**: Uses Kubernetes Node metadata stored in etcd.
 
 > :warning: **Important:** As of Kubernetes **v1.32**, the Kubernetes registry is **no longer compatible by default** due to the `AuthorizeNodeWithSelectors` feature gate, which restricts access to Node metadata.  
@@ -622,7 +622,7 @@ Starting with **module version `v2.0.0`**, Kubernetes-based discovery is **disab
 # Disable Kubernetes-based discovery (deprecated in Kubernetes >= 1.32)
 talos_kubernetes_discovery_service_enabled = false
 
-# Enable the external SideroLabs discovery service (default)
+# Enable the external Sidero Labs discovery service (default)
 talos_siderolabs_discovery_service_enabled = true
 ```
 

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -1,5 +1,11 @@
 locals {
   allow_scheduling_on_control_plane = ((local.worker_sum + local.cluster_autoscaler_max_sum) == 0)
+  
+  # Enables Kubernetes Discovery Service if version is lower than v1.32.0
+  kubernetes_discovery_service_enabled = can(regex(
+    "^v(?:0\\.[0-9]+\\.[0-9]+|1\\.(?:[0-9]|[12][0-9]|3[01])\\.[0-9]+)$",
+    var.kubernetes_version,
+  ))
 
   # Kubernetes Manifests for Talos
   talos_inline_manifests = concat(
@@ -266,8 +272,8 @@ locals {
         discovery = {
           enabled = true,
           registries = {
-            kubernetes = { disabled = false }
-            service    = { disabled = true }
+            kubernetes = { disabled = !local.kubernetes_discovery_service_enabled }
+            service    = { disabled = local.kubernetes_discovery_service_enabled }
           }
         }
         etcd = {
@@ -392,8 +398,8 @@ locals {
         discovery = {
           enabled = true,
           registries = {
-            kubernetes = { disabled = false }
-            service    = { disabled = true }
+            kubernetes = { disabled = !local.kubernetes_discovery_service_enabled }
+            service    = { disabled = local.kubernetes_discovery_service_enabled }
           }
         }
       }

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -1,11 +1,5 @@
 locals {
   allow_scheduling_on_control_plane = ((local.worker_sum + local.cluster_autoscaler_max_sum) == 0)
-  
-  # Enables Kubernetes Discovery Service if version is lower than v1.32.0
-  kubernetes_discovery_service_enabled = can(regex(
-    "^v(?:0\\.[0-9]+\\.[0-9]+|1\\.(?:[0-9]|[12][0-9]|3[01])\\.[0-9]+)$",
-    var.kubernetes_version,
-  ))
 
   # Kubernetes Manifests for Talos
   talos_inline_manifests = concat(
@@ -272,8 +266,8 @@ locals {
         discovery = {
           enabled = true,
           registries = {
-            kubernetes = { disabled = !local.kubernetes_discovery_service_enabled }
-            service    = { disabled = local.kubernetes_discovery_service_enabled }
+            kubernetes = { disabled = !var.talos_kubernetes_discovery_service_enabled }
+            service    = { disabled = !var.talos_siderolabs_discovery_service_enabled }
           }
         }
         etcd = {
@@ -398,8 +392,8 @@ locals {
         discovery = {
           enabled = true,
           registries = {
-            kubernetes = { disabled = !local.kubernetes_discovery_service_enabled }
-            service    = { disabled = local.kubernetes_discovery_service_enabled }
+            kubernetes = { disabled = !var.talos_kubernetes_discovery_service_enabled }
+            service    = { disabled = !var.talos_siderolabs_discovery_service_enabled }
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -509,6 +509,18 @@ variable "talos_image_extensions" {
   description = "Specifies Talos image extensions for additional functionality on top of the default Talos Linux capabilities. See: https://github.com/siderolabs/extensions"
 }
 
+variable "talos_kubernetes_discovery_service_enabled" {
+  description = "Enable or disable Kubernetes-based Talos discovery service. Deprecated as of Kubernetes v1.32, where the AuthorizeNodeWithSelectors feature gate is enabled by default."
+  type        = bool
+  default     = false
+}
+
+variable "talos_siderolabs_discovery_service_enabled" {
+  description = "Enable or disable Sidero Labs public Talos discovery service."
+  type        = bool
+  default     = true
+}
+
 variable "talos_kubelet_extra_mounts" {
   type = list(object({
     source      = string


### PR DESCRIPTION
Hi! 👋

Talos Kubernetes registry support is deprecated starting in Kubernetes v1.32 due to the AuthorizeNodeWithSelectors feature gate being enabled by default.

To maintain cluster health checks in preparation to the module v2.x.x with Talos v1.9/K8s v1.32 , this PR enables the public SideroLabs discovery service when the target K8s version is equal or higher than v1.32. 
According to the documentation, this approach remains secure for cluster owners, as all data is encrypted using AES-GCM and can only be decrypted by the nodes themselves.

I have managed to successfully update to Talos v1.9/K8s v1.32 with this change with healthchecks working correctly.

Reference:
https://github.com/siderolabs/talos/issues/9980
https://www.talos.dev/v1.9/talos-guides/discovery/#kubernetes-registry 
https://www.talos.dev/v1.9/talos-guides/discovery/#discovery-service-registry