### PR TITLE
feat(bootstrap): improve handling of Talos bootstrap manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ Before delegating lifecycle control to other tools, you must **first remove the 
 ```hcl
 # Core Component Configuration
 cilium_enabled                     = true  # Enabled by default
+talos_backup_s3_enabled            = true  # Enabled by default
 talos_ccm_enabled                  = true  # Enabled by default
 talos_coredns_enabled              = true  # Enabled by default
 hcloud_ccm_enabled                 = true  # Enabled by default

--- a/README.md
+++ b/README.md
@@ -600,6 +600,87 @@ talos_backup_schedule = "0 * * * *"
 To recover from a snapshot, please refer to the Talos Disaster Recovery section in the [Documentation](https://www.talos.dev/latest/advanced/disaster-recovery/#recovery).
 </details>
 
+<!-- Talos Bootstrap Manifests -->
+<details>
+<summary><b>Talos Bootstrap Manifests</b></summary>
+
+### Toggle Component Deployment in Bootstrap Manifests
+
+During the cluster provisioning phase, each component manifest is applied using Talos's bootstrap manifests feature. However, this also means that the manifests are **re-applied** every time `terraform apply` is run, as part of the [automated Kubernetes upgrade process](https://www.talos.dev/v1.8/kubernetes-guides/upgrading-kubernetes/#automated-kubernetes-upgrade) triggered by the module.
+
+This behavior can cause issues if you want to use GitOps tools like **FluxCD** or **ArgoCD** to manage the lifecycle of these components. Since Talos manages the application lifecycle, any changes made by FluxCD or ArgoCD (e.g., annotations or labels) may be overwritten or removed during upgrades, leading to conflicts.
+
+Before delegating lifecycle control to other tools, you must **first remove the corresponding manifests from the Talos machine configuration**. This can be done after the initial cluster provisioning using the following Terraform variables:
+
+```hcl
+# Core Component Configuration
+cilium_enabled                     = true  # Enabled by default
+talos_ccm_enabled                  = true  # Enabled by default
+talos_coredns_enabled              = true  # Enabled by default
+hcloud_ccm_enabled                 = true  # Enabled by default
+hcloud_csi_enabled                 = true  # Enabled by default
+cert_manager_enabled               = true  # Disabled by default
+ingress_nginx_enabled              = true  # Disabled by default
+longhorn_enabled                   = true  # Disabled by default
+metrics_server_enabled             = true  # Enabled by default
+prometheus_operator_crds_enabled   = true  # Enabled by default
+
+# Talos etcd backup is automatically enabled when any of the following S3 settings are defined
+talos_backup_s3_endpoint    = "https://..."
+talos_backup_s3_hcloud_url  = "https://<bucket>.<location>.your-objectstorage.com"
+
+# Cluster Autoscaler Configuration
+# Automatically enabled when one or more node pools are defined
+cluster_autoscaler_nodepools = [
+  {
+    name     = "autoscaler"
+    type     = "cpx11"
+    location = "fsn1"
+    min      = 0
+    max      = 6
+    labels   = {
+      "autoscaler-node" = "true"
+    }
+    taints   = [
+      "autoscaler-node=true:NoExecute"
+    ]
+  }
+]
+```
+
+> **Note:** Disabling a component **does not delete** its deployed resources. This is explicitly stated in the [Talos documentation](https://www.talos.dev/v1.8/kubernetes-guides/upgrading-kubernetes/#automated-kubernetes-upgrade).
+
+After removing the component from the bootstrap manifests, you can either delete the existing resources manually before reapplying, or allow FluxCD/ArgoCD to take over their reconciliation and ongoing management.
+
+### Adding Additional Manifests
+
+In addition to the default components, you can also include extra bootstrap manifests using the variables below:
+
+```hcl
+# Extra remote manifests (fetched from the internet)
+talos_extra_remote_manifests = [
+  "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml"
+]
+
+# Extra inline manifests (defined directly in Terraform)
+talos_extra_inline_manifests = [
+  {
+    name = "test-manifest"
+    contents = <<-EOF
+      ---
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: test-secret
+      data:
+        secret: dGVzdA==
+    EOF
+  }
+]
+```
+
+</details>
+
 <!-- Lifecycle -->
 ## :recycle: Lifecycle
 The [Talos Terraform Provider](https://registry.terraform.io/providers/siderolabs/talos) does not support declarative upgrades of Talos or Kubernetes versions. This module compensates for these limitations using `talosctl` to implement the required functionalities. Any minor or major upgrades to Talos and Kubernetes will result in a major version change of this module. Please be aware that downgrades are typically neither supported nor tested.

--- a/cilium.tf
+++ b/cilium.tf
@@ -121,8 +121,8 @@ data "helm_template" "cilium" {
 }
 
 locals {
-  cilium_manifest = {
+  cilium_manifest = var.cilium_enabled ? {
     name     = "cilium"
     contents = data.helm_template.cilium.manifest
-  }
+  } : null
 }

--- a/hcloud.tf
+++ b/hcloud.tf
@@ -47,10 +47,10 @@ data "helm_template" "hcloud_ccm" {
 }
 
 locals {
-  hcloud_ccm_manifest = {
+  hcloud_ccm_manifest = var.hcloud_ccm_enabled ? {
     name     = "hcloud-ccm"
     contents = data.helm_template.hcloud_ccm.manifest
-  }
+  } : null
 }
 
 # Hcloud CSI

--- a/talos_backup.tf
+++ b/talos_backup.tf
@@ -1,5 +1,4 @@
 locals {
-  talos_backup_s3_enabled  = var.talos_backup_s3_hcloud_url != null ? true : var.talos_backup_s3_endpoint != null ? true : false
   talos_backup_s3_hcloud   = var.talos_backup_s3_hcloud_url != null ? regex("^(?:https?://)?(?P<bucket>[^.]+)\\.(?P<region>[^.]+)\\.your-objectstorage\\.com\\.?$", var.talos_backup_s3_hcloud_url) : {}
   talos_backup_s3_bucket   = var.talos_backup_s3_hcloud_url != null ? local.talos_backup_s3_hcloud.bucket : var.talos_backup_s3_bucket
   talos_backup_s3_region   = var.talos_backup_s3_hcloud_url != null ? local.talos_backup_s3_hcloud.region : var.talos_backup_s3_region
@@ -97,7 +96,7 @@ locals {
     }
   }
 
-  talos_backup_manifest = local.talos_backup_s3_enabled ? {
+  talos_backup_manifest = var.talos_backup_s3_enabled ? {
     name     = "talos-backup"
     contents = <<-EOF
       ${yamlencode(local.talos_backup_service_account)}

--- a/talos_backup.tf
+++ b/talos_backup.tf
@@ -1,4 +1,5 @@
 locals {
+  talos_backup_s3_enabled  = var.talos_backup_s3_hcloud_url != null ? true : var.talos_backup_s3_endpoint != null ? true : false
   talos_backup_s3_hcloud   = var.talos_backup_s3_hcloud_url != null ? regex("^(?:https?://)?(?P<bucket>[^.]+)\\.(?P<region>[^.]+)\\.your-objectstorage\\.com\\.?$", var.talos_backup_s3_hcloud_url) : {}
   talos_backup_s3_bucket   = var.talos_backup_s3_hcloud_url != null ? local.talos_backup_s3_hcloud.bucket : var.talos_backup_s3_bucket
   talos_backup_s3_region   = var.talos_backup_s3_hcloud_url != null ? local.talos_backup_s3_hcloud.region : var.talos_backup_s3_region
@@ -96,7 +97,7 @@ locals {
     }
   }
 
-  talos_backup_manifest = {
+  talos_backup_manifest = local.talos_backup_s3_enabled ? {
     name     = "talos-backup"
     contents = <<-EOF
       ${yamlencode(local.talos_backup_service_account)}
@@ -105,5 +106,5 @@ locals {
       ---
       ${yamlencode(local.talos_backup_cronjob)}
     EOF
-  }
+  } : null
 }

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -3,23 +3,23 @@ locals {
 
   # Kubernetes Manifests for Talos
   talos_inline_manifests = concat(
-    [
-      local.talos_backup_manifest,
-      local.hcloud_secret_manifest,
-      local.hcloud_ccm_manifest,
-      local.cilium_manifest
-    ],
+    [local.hcloud_secret_manifest],
+    local.cilium_manifest != null ? [local.cilium_manifest] : [],
+    local.hcloud_ccm_manifest != null ? [local.hcloud_ccm_manifest] : [],
     local.hcloud_csi_manifest != null ? [local.hcloud_csi_manifest] : [],
+    local.talos_backup_manifest != null ? [local.talos_backup_manifest] : [],
     local.longhorn_manifest != null ? [local.longhorn_manifest] : [],
     local.metrics_server_manifest != null ? [local.metrics_server_manifest] : [],
     local.cert_manager_manifest != null ? [local.cert_manager_manifest] : [],
     local.ingress_nginx_manifest != null ? [local.ingress_nginx_manifest] : [],
-    local.cluster_autoscaler_manifest != null ? [local.cluster_autoscaler_manifest] : []
+    local.cluster_autoscaler_manifest != null ? [local.cluster_autoscaler_manifest] : [],
+    var.talos_extra_inline_manifests != null ? var.talos_extra_inline_manifests : []
   )
-  talos_manifests = [
-    "https://raw.githubusercontent.com/siderolabs/talos-cloud-controller-manager/${var.talos_ccm_version}/docs/deploy/cloud-controller-manager-daemonset.yml",
-    "https://github.com/prometheus-operator/prometheus-operator/releases/download/${var.prometheus_operator_crds_version}/stripped-down-crds.yaml"
-  ]
+  talos_manifests = concat(
+    var.talos_ccm_enabled ? ["https://raw.githubusercontent.com/siderolabs/talos-cloud-controller-manager/${var.talos_ccm_version}/docs/deploy/cloud-controller-manager-daemonset.yml"] : [],
+    var.prometheus_operator_crds_enabled ? ["https://github.com/prometheus-operator/prometheus-operator/releases/download/${var.prometheus_operator_crds_version}/stripped-down-crds.yaml"] : [],
+    var.talos_extra_remote_manifests != null ? var.talos_extra_remote_manifests : []
+  )
 
   # Talos and Kubernetes Certificates
   certificate_san = sort(

--- a/variables.tf
+++ b/variables.tf
@@ -689,6 +689,12 @@ variable "talos_backup_version" {
   description = "Specifies the version of Talos Backup to be used in generated machine configurations."
 }
 
+variable "talos_backup_s3_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable Talos etcd S3 backup cronjob."
+}
+
 variable "talos_backup_s3_hcloud_url" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -667,6 +667,21 @@ variable "talos_service_log_destinations" {
   default = []
 }
 
+variable "talos_extra_inline_manifests" {
+  type = list(object({
+    name     = string
+    contents = string
+  }))
+  description = "List of additional inline Kubernetes manifests to append to the Talos machine configuration during bootstrap."
+  default     = null
+}
+
+variable "talos_extra_remote_manifests" {
+  type        = list(string)
+  description = "List of remote URLs pointing to Kubernetes manifests to be appended to the Talos machine configuration during bootstrap."
+  default     = null
+}
+
 # Talos Backup
 variable "talos_backup_version" {
   type        = string
@@ -784,6 +799,11 @@ variable "kube_api_extra_args" {
 
 
 # Talos CCM
+variable "talos_ccm_enabled" {
+  type        = bool
+  default     = true
+  description = "Enables the Talos Cloud Controller Manager (CCM) deployment."
+}
 variable "talos_ccm_version" {
   type        = string
   default     = "v1.9.0" # https://github.com/siderolabs/talos-cloud-controller-manager
@@ -832,6 +852,11 @@ variable "hcloud_load_balancer_location" {
 
 
 # Hetzner Cloud Controller Manager (CCM)
+variable "hcloud_ccm_enabled" {
+  type        = bool
+  default     = true
+  description = "Enables the Hetzner Cloud Controller Manager (CCM)."
+}
 variable "hcloud_ccm_helm_repository" {
   type        = string
   default     = "https://charts.hetzner.cloud"
@@ -922,6 +947,11 @@ variable "longhorn_enabled" {
 
 
 # Cilium
+variable "cilium_enabled" {
+  type        = bool
+  default     = true
+  description = "Enables the Cilium CNI deployment."
+}
 variable "cilium_helm_repository" {
   type        = string
   default     = "https://helm.cilium.io"
@@ -1341,6 +1371,11 @@ variable "ingress_load_balancer_pools" {
 
 
 # Miscellaneous
+variable "prometheus_operator_crds_enabled" {
+  type        = bool
+  default     = true
+  description = "Enables the Prometheus Operator Custom Resource Definitions (CRDs) deployment."
+}
 variable "prometheus_operator_crds_version" {
   type        = string
   default     = "v0.81.0" # https://github.com/prometheus-operator/prometheus-operator


### PR DESCRIPTION
Hi! 👋

This PR improves the flexibility and correctness of Talos bootstrap manifest handling. It introduces the ability to selectively enable or disable each default component, fixes unintended behavior in the etcd backup logic, and adds support for custom user-defined manifests during the bootstrap phase.

- Add support to enable/disable all default components, allowing users to delegate deployment to tools like ArgoCD. Fixes #93 
Users can now explicitly enable or disable each individual bootstrap component.
This is particularly useful when transitioning component lifecycle management to GitOps tools like ArgoCD or FluxCD, where Talos should no longer manage those resources.

  This change partly fixes [#93] by allowing users to fully control each component lifecycle.

- Fix issue where Talos S3 backup manifests were applied even when not explicitly enabled, preventing broken CronJobs
Previously, the Talos etcd backup manifests were being applied even if the backup feature wasn't enabled, resulting in a broken or non-functional CronJob.

  This has been corrected, the backup manifests are now only included when backup-related configuration (e.g., talos_backup_s3_endpoint) is explicitly set by the user.

- Add support for user-defined inline and remote manifests in the bootstrap process. Fixes #93 
  Users can now inject additional manifests during the bootstrap phase by specifying:

    -   **talos_extra_inline_manifests**: Inline manifest definitions embedded directly in Terraform.
    -   **talos_extra_remote_manifests**: URLs pointing to remote YAML manifests.

  
  This allows users to bootstrap any extra resources alongside the default components, giving more control over cluster setup without needing custom scripts.