### PR TITLE
feat(hcloud): Talos snapshot images improvements

### DIFF
--- a/image.tf
+++ b/image.tf
@@ -36,6 +36,7 @@ locals {
 
   talos_image_extensions = distinct(
     concat(
+      ["siderolabs/qemu-guest-agent"],
       var.talos_image_extensions,
       var.longhorn_enabled ? local.talos_image_extentions_longhorn : []
     )

--- a/packer/image_amd64.pkr.hcl
+++ b/packer/image_amd64.pkr.hcl
@@ -47,6 +47,10 @@ build {
       <<-EOT
         set -euo pipefail
 
+        # Discard the entire /dev/sda to free up space and make the snapshot smaller
+        echo 'Zeroing disk first before writing Talos image'
+        blkdiscard /dev/sda 2>/dev/null
+
         echo 'Download Talos ${var.talos_version} image (${var.talos_schematic_id})'
 
         wget \

--- a/packer/image_arm64.pkr.hcl
+++ b/packer/image_arm64.pkr.hcl
@@ -47,6 +47,10 @@ build {
       <<-EOT
         set -euo pipefail
 
+        # Discard the entire /dev/sda to free up space and make the snapshot smaller
+        echo 'Zeroing disk first before writing Talos image'
+        blkdiscard /dev/sda 2>/dev/null
+
         echo 'Download Talos ${var.talos_version} image (${var.talos_schematic_id})'
 
         wget \


### PR DESCRIPTION
Hi! 👋
This PR includes two key improvements to Talos snapshot bootstrap images.

📌 Summary of Changes

1. **Enabled QEMU Guest Agent (GA) by default**
  As documented in the [Hetzner changelog](https://docs.hetzner.cloud/changelog#2025-04-23-talos-linux-v195-iso-now-available) and the [Talos Hetzner guide](https://www.talos.dev/v1.9/talos-guides/install/cloud-platforms/hetzner/#upload-image), the QEMU Guest Agent is now enabled by default in their builds, so i guess we should match that as-well.

2. **Reduced snapshot size by using blkdiscard before writing the image**
  This change significantly reduces the final snapshot size and node bootstrap times by zeroing out the disk before writing the Talos image, as originally proposed in [hcloud-upload-image project issue #96 ](https://github.com/apricote/hcloud-upload-image/issues/96).
![Captura desde 2025-05-10 16-20-29](https://github.com/user-attachments/assets/807eb7a7-a0b8-453e-8c9e-55bdf4718120)
![Captura desde 2025-05-10 16-37-55](https://github.com/user-attachments/assets/372e1208-702a-4bb9-a3b2-1c88c4ff3fc2)

Regards!
