### PR TITLE
fix(module): Talos configuration patches generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,62 @@ talos_siderolabs_discovery_service_enabled = true
 For more details, refer to the [official Talos discovery guide](https://www.talos.dev/latest/talos-guides/discovery/).
 </details>
 
+<!-- Talos Configuration Patches -->
+<details>
+<summary><b>Talos Configuration Patches</b></summary>
+
+In this module you can declare [Talos Configuration Patches](https://www.talos.dev/v1.9/talos-guides/configuration/patching/) via three map variables:
+
+- **control_plane_config_patches**: patches applied to control‐plane nodes.
+- **worker_config_patches**: patches applied to worker nodes.
+- **cluster_autoscaler_config_patches**: patches applied to cluster‐autoscaler nodes.
+
+For all three:
+
+- **Map key** = the Kubernetes object’s `metadata.name`.
+- **Map value** = the full Kubernetes‑style object, where the `spec` block contains exactly the inner YAML you wish to inject.
+
+##### Example
+
+```hcl
+# Control plane patches
+control_plane_config_patches = {
+  tailscale = {
+    apiVersion = "v1alpha1"
+    kind       = "ExtensionServiceConfig"
+    spec = {
+      environment = [
+        "TS_AUTHKEY=test",
+        "TS_ROUTES=test",
+      ]
+    }
+  }
+}
+
+# Worker node patches
+worker_config_patches = {
+  nut-client = {
+    apiVersion = "v1alpha1"
+    kind       = "ExtensionServiceConfig"
+    spec = {
+      configFiles = [{
+        content   = "MONITOR upsmonHost 1 remote username password"
+        mountPath = "/usr/local/etc/nut/upsmon.conf"
+      }]
+      environment = ["NUT_UPS=test"]
+    }
+  }
+}
+
+# Cluster‑autoscaler node patches
+cluster_autoscaler_config_patches = {}
+```
+
+> [!NOTE]
+> The **key** of each map entry becomes the metadata.name of the patch object; everything under **spec** must match exactly the YAML you want Talos to apply.
+> For full details on Configuration Patches syntax and behavior, see the [Talos guide](https://www.talos.dev/v1.9/talos-guides/configuration/patching/).
+</details>
+
 <!-- Lifecycle -->
 ## :recycle: Lifecycle
 The [Talos Terraform Provider](https://registry.terraform.io/providers/siderolabs/talos) does not support declarative upgrades of Talos or Kubernetes versions. This module compensates for these limitations using `talosctl` to implement the required functionalities. Any minor or major upgrades to Talos and Kubernetes will result in a major version change of this module. Please be aware that downgrades are typically neither supported nor tested.

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -510,12 +510,31 @@ data "talos_machine_configuration" "control_plane" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "controlplane"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
+  docs               = false
+  examples           = false
   config_patches = [
-    yamlencode(local.control_plane_talos_config_patch[each.key]),
-    yamlencode(var.control_plane_config_patches)
+    join(
+      "\n",
+      flatten([
+        "---",
+        yamlencode(local.control_plane_talos_config_patch[each.key]),
+        [
+          for name, patch in var.control_plane_config_patches :
+          join("\n", [
+            "---",
+            yamlencode(merge(
+              {
+                apiVersion = patch.apiVersion
+                kind       = patch.kind
+                name       = name
+              },
+              patch.spec
+            ))
+          ])
+        ]
+      ])
+    )
   ]
-  docs     = false
-  examples = false
 }
 
 data "talos_machine_configuration" "worker" {
@@ -527,12 +546,31 @@ data "talos_machine_configuration" "worker" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
+  docs               = false
+  examples           = false
   config_patches = [
-    yamlencode(local.worker_talos_config_patch[each.key]),
-    yamlencode(var.worker_config_patches)
+    join(
+      "\n",
+      flatten([
+        "---",
+        yamlencode(local.worker_talos_config_patch[each.key]),
+        [
+          for name, patch in var.worker_config_patches :
+          join("\n", [
+            "---",
+            yamlencode(merge(
+              {
+                apiVersion = patch.apiVersion
+                kind       = patch.kind
+                name       = name
+              },
+              patch.spec
+            ))
+          ])
+        ]
+      ])
+    )
   ]
-  docs     = false
-  examples = false
 }
 
 data "talos_machine_configuration" "cluster_autoscaler" {
@@ -544,10 +582,29 @@ data "talos_machine_configuration" "cluster_autoscaler" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
+  docs               = false
+  examples           = false
   config_patches = [
-    yamlencode(local.autoscaler_nodepool_talos_config_patch[each.key]),
-    yamlencode(var.cluster_autoscaler_config_patches)
+    join(
+      "\n",
+      flatten([
+        "---",
+        yamlencode(local.autoscaler_nodepool_talos_config_patch[each.key]),
+        [
+          for name, patch in var.cluster_autoscaler_config_patches :
+          join("\n", [
+            "---",
+            yamlencode(merge(
+              {
+                apiVersion = patch.apiVersion
+                kind       = patch.kind
+                name       = name
+              },
+              patch.spec
+            ))
+          ])
+        ]
+      ])
+    )
   ]
-  docs     = false
-  examples = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -322,9 +322,9 @@ variable "control_plane_nodepools" {
 }
 
 variable "control_plane_config_patches" {
-  type        = list(any)
-  default     = []
-  description = "List of configuration patches applied to the Control Plane nodes."
+  type        = any
+  default     = {}
+  description = "Map of configuration patches applied to the Control Plane nodes."
 }
 
 
@@ -400,9 +400,9 @@ variable "worker_nodepools" {
 }
 
 variable "worker_config_patches" {
-  type        = list(any)
-  default     = []
-  description = "List of configuration patches applied to the Worker nodes."
+  type        = any
+  default     = {}
+  description = "Map of configuration patches applied to the Worker nodes."
 }
 
 
@@ -484,9 +484,9 @@ variable "cluster_autoscaler_nodepools" {
 }
 
 variable "cluster_autoscaler_config_patches" {
-  type        = list(any)
-  default     = []
-  description = "List of configuration patches applied to the Cluster Autoscaler nodes."
+  type        = any
+  default     = {}
+  description = "Map of configuration patches applied to the Cluster Autoscaler nodes."
 }
 
 


### PR DESCRIPTION
Hi! 👋
This PR fixes Talos configuration patches handling by the module.

📌 Summary of Changes
- Ensure generated MachineConfig includes proper YAML document separators (fixes #90, #91)
