### PR TITLE
Conditionally disable `ACMEHTTP01IngressPathTypeExact` for ingress-nginx compatibility

### DIFF
--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -62,6 +62,15 @@ data "helm_template" "cert_manager" {
   values = [
     yamlencode(
       merge(
+        {
+          config = {
+            featureGates = {
+              # Disable the use of Exact PathType in Ingress resources, to work around a bug in ingress-nginx
+              # https://github.com/kubernetes/ingress-nginx/issues/11176
+              ACMEHTTP01IngressPathTypeExact = !var.ingress_nginx_enabled
+            }
+          }
+        },
         local.cert_manager_values,
         {
           webhook = merge(


### PR DESCRIPTION
This PR disables the `ACMEHTTP01IngressPathTypeExact` feature gate when `ingress-nginx` is enabled. The change addresses a known bug in ingress-nginx (see https://github.com/kubernetes/ingress-nginx/issues/11176) that rejects valid ACME HTTP01 challenge paths when using `Exact` as the PathType.

The strict path validation in ingress-nginx >=1.12.0 breaks compatibility with URLs containing dots, such as `/.well-known/acme-challenge/<TOKEN>`. This conditional logic preserves compatibility with nginx while retaining the stricter `Exact` PathType for standards-compliant ingress controllers like Cilium.