### PR TITLE
Fix config patches to support strategic merge patches and RFC6902 JSON patches

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -510,12 +510,13 @@ data "talos_machine_configuration" "control_plane" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "controlplane"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
-  config_patches = [
-    yamlencode(local.control_plane_talos_config_patch[each.key]),
-    yamlencode(var.control_plane_config_patches)
-  ]
-  docs     = false
-  examples = false
+  docs               = false
+  examples           = false
+
+  config_patches = concat(
+    [yamlencode(local.control_plane_talos_config_patch[each.key])],
+    [for patch in var.control_plane_config_patches : yamlencode(patch)]
+  )
 }
 
 data "talos_machine_configuration" "worker" {
@@ -527,12 +528,13 @@ data "talos_machine_configuration" "worker" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
-  config_patches = [
-    yamlencode(local.worker_talos_config_patch[each.key]),
-    yamlencode(var.worker_config_patches)
-  ]
-  docs     = false
-  examples = false
+  docs               = false
+  examples           = false
+
+  config_patches = concat(
+    [yamlencode(local.worker_talos_config_patch[each.key])],
+    [for patch in var.worker_config_patches : yamlencode(patch)]
+  )
 }
 
 data "talos_machine_configuration" "cluster_autoscaler" {
@@ -544,10 +546,11 @@ data "talos_machine_configuration" "cluster_autoscaler" {
   kubernetes_version = var.kubernetes_version
   machine_type       = "worker"
   machine_secrets    = talos_machine_secrets.this.machine_secrets
-  config_patches = [
-    yamlencode(local.autoscaler_nodepool_talos_config_patch[each.key]),
-    yamlencode(var.cluster_autoscaler_config_patches)
-  ]
-  docs     = false
-  examples = false
+  docs               = false
+  examples           = false
+
+  config_patches = concat(
+    [yamlencode(local.autoscaler_nodepool_talos_config_patch[each.key])],
+    [for patch in var.cluster_autoscaler_config_patches : yamlencode(patch)]
+  )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -322,7 +322,7 @@ variable "control_plane_nodepools" {
 }
 
 variable "control_plane_config_patches" {
-  type        = list(any)
+  type        = any
   default     = []
   description = "List of configuration patches applied to the Control Plane nodes."
 }
@@ -400,7 +400,7 @@ variable "worker_nodepools" {
 }
 
 variable "worker_config_patches" {
-  type        = list(any)
+  type        = any
   default     = []
   description = "List of configuration patches applied to the Worker nodes."
 }
@@ -484,7 +484,7 @@ variable "cluster_autoscaler_nodepools" {
 }
 
 variable "cluster_autoscaler_config_patches" {
-  type        = list(any)
+  type        = any
   default     = []
   description = "List of configuration patches applied to the Cluster Autoscaler nodes."
 }


### PR DESCRIPTION
Fixes #90

The config patch options introduced in #22 only supported RFC 6902 JSON patches. This PR adds support for strategic merge patches as well, enabling a hybrid configuration approach as documented [here](https://www.talos.dev/v1.10/talos-guides/configuration/patching/) and supported also by the `talos_machine_configuration` data source.

Example:

```hcl
control_plane_config_patches = [
  [
    {
      op    = "remove"
      path  = "/cluster/apiServer/admissionControl"
    }
  ],
  {
    apiVersion = "v1alpha1"
    kind       = "SideroLinkConfig"
    apiUrl     = "https://siderolink.api"
  }
]
```