### PR TITLE
feat: add OIDC authentication and custom RBAC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -915,7 +915,7 @@ oidc_group_mappings = [                                  # List of OIDC group ma
 
 #### Client Configuration with kubelogin
 
-Once OIDC is configured on your cluster, you'll need to configure your local kubectl to authenticate using OIDC tokens. This requires the [kubelogin](https://github.com/int128/kubelogin) plugin.
+Once OIDC is configured in your cluster, you'll need to configure your local kubectl to authenticate using OIDC tokens. This requires the [kubelogin](https://github.com/int128/kubelogin) plugin.
 
 ##### Install kubelogin
 
@@ -939,7 +939,7 @@ kubectl oidc-login setup \
   --oidc-issuer-url=https://your-oidc-provider.com \
   --oidc-client-id=your-client-id \
   --oidc-client-secret=your-client-secret \           
-  --oidc-extra-scope=openid,email,profile             # Change the scopes according to your IDP
+  --oidc-extra-scope=openid,email,profile             # Add or change the scopes according to your IDP
 ```
 
 This will open your browser for authentication. After successful login, you should see a JWT token in your terminal that looks like:
@@ -986,7 +986,7 @@ users:
         - --oidc-client-secret=your-client-secret
         - --oidc-extra-scope=groups
         - --oidc-extra-scope=email
-        - --oidc-extra-scope=name
+        - --oidc-extra-scope=name                           # Add or change the scopes according to your IDP
 ```
 
 Update your context to use the new OIDC user:

--- a/README.md
+++ b/README.md
@@ -840,8 +840,9 @@ These custom roles can be used independently or combined with OIDC group mapping
 ##### Cluster Roles (`rbac_cluster_roles`)
 
 ```hcl
-rbac_cluster_roles = {
-  "cluster-role-name" = {
+rbac_cluster_roles = [
+  {
+    name  = my-cluster-role                    # ClusterRole name
     rules = [
       {
         api_groups = [""]                      # Core API group (empty string for core resources)
@@ -850,14 +851,15 @@ rbac_cluster_roles = {
       }
     ]
   }
-}
+]
 ```
 
 ##### Namespaced Roles (`rbac_roles`)
 
 ```hcl
-rbac_roles = {
-  "role-name" = {
+rbac_roles = [
+  {
+    name      = "my-role"                      # Role name
     namespace = "target-namespace"             # Namespace where the role will be created
     rules = [
       {
@@ -867,7 +869,7 @@ rbac_roles = {
       }
     ]
   }
-}
+]
 ```
 
 </details>
@@ -893,11 +895,13 @@ oidc_groups_claim   = "groups"                           # OIDC JWT claim to ext
 oidc_groups_prefix  = "oidc:"                            # Prefix added to group names in K8s to avoid conflicts
 
 # Map OIDC groups to Kubernetes roles and cluster roles
-oidc_group_mappings = {                                  # Each key must match a OIDC provider group
-  "cluster-admins-group" = {                                   
+oidc_group_mappings = [                                  # List of OIDC group mappings
+  {
+    group         = "cluster-admins-group"               # OIDC provider group name
     cluster_roles = ["cluster-admin"]                    # Grant cluster-admin access
-  }
-  "developers-group" = {
+  },
+  {
+    group         = "developers-group"                   # OIDC provider group name
     cluster_roles = ["view"]                             # Grant cluster-wide view access
     roles = [                                            # Grant namespace scoped roles
       {
@@ -906,7 +910,7 @@ oidc_group_mappings = {                                  # Each key must match a
       }
     ]
   }
-}
+]
 ```
 
 #### Client Configuration with kubelogin

--- a/oidc.tf
+++ b/oidc.tf
@@ -78,7 +78,7 @@ locals {
 
   # Final manifest
   oidc_manifest = length(local.oidc_manifests) > 0 ? {
-    name     = "talos-oidc-rbac"
+    name     = "kube-oidc-rbac"
     contents = join("\n---\n", local.oidc_manifests)
   } : null
 }

--- a/oidc.tf
+++ b/oidc.tf
@@ -1,61 +1,84 @@
 locals {
-  # Create bindings for OIDC groups
+  # Collect all unique k8s cluster roles used across OIDC group mappings
+  k8s_cluster_roles = var.oidc_enabled ? toset(flatten([
+    for group_mapping in var.oidc_group_mappings : group_mapping.cluster_roles
+  ])) : toset([])
+
+  # Collect all unique k8s roles used across OIDC group mappings (grouped by namespace/role)
+  k8s_roles = var.oidc_enabled ? {
+    for role_key, role_info in merge([
+      for group_mapping in var.oidc_group_mappings : {
+        for role in group_mapping.roles : "${role.namespace}/${role.name}" => role
+      }
+    ]...) : role_key => role_info
+  } : {}
+
+  # Create one ClusterRoleBinding per cluster role with all groups as subjects
+  cluster_role_binding_manifests = [
+    for cluster_role in local.k8s_cluster_roles : yamlencode({
+      apiVersion = "rbac.authorization.k8s.io/v1"
+      kind       = "ClusterRoleBinding"
+      metadata = {
+        name = "oidc-${cluster_role}"
+      }
+      roleRef = {
+        apiGroup = "rbac.authorization.k8s.io"
+        kind     = "ClusterRole"
+        name     = cluster_role
+      }
+      subjects = [
+        for group_mapping in var.oidc_group_mappings : {
+          apiGroup = "rbac.authorization.k8s.io"
+          kind     = "Group"
+          name     = "${var.oidc_groups_prefix}${group_mapping.group}"
+        }
+        if contains(group_mapping.cluster_roles, cluster_role)
+      ]
+    })
+    if length([
+      for group_mapping in var.oidc_group_mappings : group_mapping
+      if contains(group_mapping.cluster_roles, cluster_role)
+    ]) > 0
+  ]
+
+  # Create one RoleBinding per role with all groups as subjects
+  role_binding_manifests = [
+    for role_key, role_info in local.k8s_roles : yamlencode({
+      apiVersion = "rbac.authorization.k8s.io/v1"
+      kind       = "RoleBinding"
+      metadata = {
+        name      = "oidc-${role_info.name}"
+        namespace = role_info.namespace
+      }
+      roleRef = {
+        apiGroup = "rbac.authorization.k8s.io"
+        kind     = "Role"
+        name     = role_info.name
+      }
+      subjects = [
+        for group_mapping in var.oidc_group_mappings : {
+          apiGroup = "rbac.authorization.k8s.io"
+          kind     = "Group"
+          name     = "${var.oidc_groups_prefix}${group_mapping.group}"
+        }
+        if contains([for role in group_mapping.roles : "${role.namespace}/${role.name}"], role_key)
+      ]
+    })
+    if length([
+      for group_mapping in var.oidc_group_mappings : group_mapping
+      if contains([for role in group_mapping.roles : "${role.namespace}/${role.name}"], role_key)
+    ]) > 0
+  ]
+
+  # Combine all OIDC manifests
   oidc_manifests = var.oidc_enabled ? concat(
-
-    # Cluster Role bindings
-    flatten([
-      for oidc_group, mapping in var.oidc_group_mappings : [
-        for cluster_role in mapping.cluster_roles : yamlencode({
-          apiVersion = "rbac.authorization.k8s.io/v1"
-          kind       = "ClusterRoleBinding"
-          metadata = {
-            name = "${oidc_group}-${cluster_role}"
-          }
-          roleRef = {
-            apiGroup = "rbac.authorization.k8s.io"
-            kind     = "ClusterRole"
-            name     = cluster_role
-          }
-          subjects = [
-            {
-              apiGroup = "rbac.authorization.k8s.io"
-              kind     = "Group"
-              name     = "${var.oidc_groups_prefix}${oidc_group}"
-            }
-          ]
-        })
-      ]
-    ]),
-
-    # Role bindings
-    flatten([
-      for oidc_group, mapping in var.oidc_group_mappings : [
-        for role in mapping.roles : yamlencode({
-          apiVersion = "rbac.authorization.k8s.io/v1"
-          kind       = "RoleBinding"
-          metadata = {
-            name      = "${oidc_group}-${role.name}"
-            namespace = role.namespace
-          }
-          roleRef = {
-            apiGroup = "rbac.authorization.k8s.io"
-            kind     = "Role"
-            name     = role.name
-          }
-          subjects = [
-            {
-              apiGroup = "rbac.authorization.k8s.io"
-              kind     = "Group"
-              name     = "${var.oidc_groups_prefix}${oidc_group}"
-            }
-          ]
-        })
-      ]
-    ])
+    local.cluster_role_binding_manifests,
+    local.role_binding_manifests
   ) : []
 
+  # Final manifest
   oidc_manifest = length(local.oidc_manifests) > 0 ? {
-    name     = "talos-oidc"
+    name     = "talos-oidc-rbac"
     contents = join("\n---\n", local.oidc_manifests)
   } : null
 }

--- a/oidc.tf
+++ b/oidc.tf
@@ -1,0 +1,61 @@
+locals {
+  # Create bindings for OIDC groups
+  oidc_manifests = var.oidc_enabled ? concat(
+
+    # Cluster Role bindings
+    flatten([
+      for oidc_group, mapping in var.oidc_group_mappings : [
+        for cluster_role in mapping.cluster_roles : yamlencode({
+          apiVersion = "rbac.authorization.k8s.io/v1"
+          kind       = "ClusterRoleBinding"
+          metadata = {
+            name = "${oidc_group}-${cluster_role}"
+          }
+          roleRef = {
+            apiGroup = "rbac.authorization.k8s.io"
+            kind     = "ClusterRole"
+            name     = cluster_role
+          }
+          subjects = [
+            {
+              apiGroup = "rbac.authorization.k8s.io"
+              kind     = "Group"
+              name     = "${var.oidc_groups_prefix}${oidc_group}"
+            }
+          ]
+        })
+      ]
+    ]),
+
+    # Role bindings
+    flatten([
+      for oidc_group, mapping in var.oidc_group_mappings : [
+        for role in mapping.roles : yamlencode({
+          apiVersion = "rbac.authorization.k8s.io/v1"
+          kind       = "RoleBinding"
+          metadata = {
+            name      = "${oidc_group}-${role.name}"
+            namespace = role.namespace
+          }
+          roleRef = {
+            apiGroup = "rbac.authorization.k8s.io"
+            kind     = "Role"
+            name     = role.name
+          }
+          subjects = [
+            {
+              apiGroup = "rbac.authorization.k8s.io"
+              kind     = "Group"
+              name     = "${var.oidc_groups_prefix}${oidc_group}"
+            }
+          ]
+        })
+      ]
+    ])
+  ) : []
+
+  oidc_manifest = length(local.oidc_manifests) > 0 ? {
+    name     = "talos-oidc"
+    contents = join("\n---\n", local.oidc_manifests)
+  } : null
+}

--- a/rbac.tf
+++ b/rbac.tf
@@ -31,7 +31,7 @@ locals {
   )
 
   rbac_manifest = length(local.rbac_manifests) > 0 ? {
-    name     = "talos-rbac"
+    name     = "kube-rbac"
     contents = join("\n---\n", local.rbac_manifests)
   } : null
 }

--- a/rbac.tf
+++ b/rbac.tf
@@ -2,27 +2,27 @@ locals {
   # Generate Kubernetes RBAC manifests
   rbac_manifests = concat(
     # Kubernetes namespaced roles
-    [for role_name, role_config in var.rbac_roles : yamlencode({
+    [for role in var.rbac_roles : yamlencode({
       apiVersion = "rbac.authorization.k8s.io/v1"
       kind       = "Role"
       metadata = {
-        name      = role_name
-        namespace = role_config.namespace
+        name      = role.name
+        namespace = role.namespace
       }
-      rules = [for rule in role_config.rules : {
+      rules = [for rule in role.rules : {
         apiGroups = rule.api_groups
         resources = rule.resources
         verbs     = rule.verbs
       }]
     })],
     # Kubernetes cluster roles 
-    [for role_name, role_config in var.rbac_cluster_roles : yamlencode({
+    [for role in var.rbac_cluster_roles : yamlencode({
       apiVersion = "rbac.authorization.k8s.io/v1"
       kind       = "ClusterRole"
       metadata = {
-        name = role_name
+        name = role.name
       }
-      rules = [for rule in role_config.rules : {
+      rules = [for rule in role.rules : {
         apiGroups = rule.api_groups
         resources = rule.resources
         verbs     = rule.verbs

--- a/rbac.tf
+++ b/rbac.tf
@@ -1,0 +1,38 @@
+locals {
+  # Generate Kubernetes RBAC manifests
+  rbac_manifests = concat(
+    # Kubernetes namespaced roles
+    [for role_name, role_config in var.rbac_roles : yamlencode({
+      apiVersion = "rbac.authorization.k8s.io/v1"
+      kind       = "Role"
+      metadata = {
+        name      = role_name
+        namespace = role_config.namespace
+      }
+      rules = [for rule in role_config.rules : {
+        apiGroups = rule.api_groups
+        resources = rule.resources
+        verbs     = rule.verbs
+      }]
+    })],
+    # Kubernetes cluster roles 
+    [for role_name, role_config in var.rbac_cluster_roles : yamlencode({
+      apiVersion = "rbac.authorization.k8s.io/v1"
+      kind       = "ClusterRole"
+      metadata = {
+        name = role_name
+      }
+      rules = [for rule in role_config.rules : {
+        apiGroups = rule.api_groups
+        resources = rule.resources
+        verbs     = rule.verbs
+      }]
+    })]
+  )
+
+  rbac_manifest = length(local.rbac_manifests) > 0 ? {
+    name     = "talos-rbac"
+    contents = join("\n---\n", local.rbac_manifests)
+  } : null
+}
+

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -1,6 +1,14 @@
 locals {
   allow_scheduling_on_control_plane = ((local.worker_sum + local.cluster_autoscaler_max_sum) == 0)
 
+  talos_oidc_configuration = var.oidc_enabled ? {
+    "oidc-issuer-url"     = var.oidc_issuer_url
+    "oidc-client-id"      = var.oidc_client_id
+    "oidc-username-claim" = var.oidc_username_claim
+    "oidc-groups-claim"   = var.oidc_groups_claim
+    "oidc-groups-prefix"  = var.oidc_groups_prefix
+  } : {}
+
   # Kubernetes Manifests for Talos
   talos_inline_manifests = concat(
     [local.hcloud_secret_manifest],
@@ -13,7 +21,9 @@ locals {
     local.cert_manager_manifest != null ? [local.cert_manager_manifest] : [],
     local.ingress_nginx_manifest != null ? [local.ingress_nginx_manifest] : [],
     local.cluster_autoscaler_manifest != null ? [local.cluster_autoscaler_manifest] : [],
-    var.talos_extra_inline_manifests != null ? var.talos_extra_inline_manifests : []
+    var.talos_extra_inline_manifests != null ? var.talos_extra_inline_manifests : [],
+    local.rbac_manifest != null ? [local.rbac_manifest] : [],
+    local.oidc_manifest != null ? [local.oidc_manifest] : []
   )
   talos_manifests = concat(
     var.talos_ccm_enabled ? ["https://raw.githubusercontent.com/siderolabs/talos-cloud-controller-manager/${var.talos_ccm_version}/docs/deploy/cloud-controller-manager-daemonset.yml"] : [],
@@ -265,6 +275,7 @@ locals {
           certSANs         = local.certificate_san,
           extraArgs = merge(
             { "enable-aggregator-routing" = true },
+            local.talos_oidc_configuration,
             var.kube_api_extra_args
           )
         }

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -1,7 +1,7 @@
 locals {
   allow_scheduling_on_control_plane = ((local.worker_sum + local.cluster_autoscaler_max_sum) == 0)
 
-  talos_oidc_configuration = var.oidc_enabled ? {
+  kube_oidc_configuration = var.oidc_enabled ? {
     "oidc-issuer-url"     = var.oidc_issuer_url
     "oidc-client-id"      = var.oidc_client_id
     "oidc-username-claim" = var.oidc_username_claim
@@ -275,7 +275,7 @@ locals {
           certSANs         = local.certificate_san,
           extraArgs = merge(
             { "enable-aggregator-routing" = true },
-            local.talos_oidc_configuration,
+            local.kube_oidc_configuration,
             var.kube_api_extra_args
           )
         }

--- a/variables.tf
+++ b/variables.tf
@@ -864,6 +864,91 @@ variable "talos_ccm_version" {
   description = "Specifies the version of the Talos Cloud Controller Manager (CCM) to use. This version controls cloud-specific integration features in the Talos operating system."
 }
 
+# Talos OIDC Configuration
+variable "oidc_enabled" {
+  description = "Enable OIDC authentication for Kubernetes API server"
+  type        = bool
+  default     = false
+}
+
+variable "oidc_issuer_url" {
+  description = "URL of the OIDC provider (e.g., https://your-oidc-provider.com). Required when oidc_enabled is true"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.oidc_enabled == false || (var.oidc_enabled == true && var.oidc_issuer_url != "")
+    error_message = "oidc_issuer_url is required when oidc_enabled is true."
+  }
+}
+
+variable "oidc_client_id" {
+  description = "OIDC client ID that all tokens must be issued for. Required when oidc_enabled is true"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.oidc_enabled == false || (var.oidc_enabled == true && var.oidc_client_id != "")
+    error_message = "oidc_client_id is required when oidc_enabled is true."
+  }
+}
+
+variable "oidc_username_claim" {
+  description = "JWT claim to use as the username"
+  type        = string
+  default     = "sub"
+}
+
+variable "oidc_groups_claim" {
+  description = "JWT claim to use as the user's groups"
+  type        = string
+  default     = "groups"
+}
+
+variable "oidc_groups_prefix" {
+  description = "Prefix prepended to group claims to prevent clashes with existing names"
+  type        = string
+  default     = "oidc:"
+}
+
+variable "oidc_group_mappings" {
+  description = "Map OIDC groups to Kubernetes roles and cluster roles"
+  type = map(object({
+    cluster_roles = optional(list(string), [])
+    roles = optional(list(object({
+      name      = string
+      namespace = string
+    })), [])
+  }))
+  default = {}
+}
+
+# Kubernetes RBAC
+variable "rbac_roles" {
+  description = "Custom Kubernetes roles to create"
+  type = map(object({
+    namespace = string
+    rules = list(object({
+      api_groups = list(string)
+      resources  = list(string)
+      verbs      = list(string)
+    }))
+  }))
+  default = {}
+}
+
+variable "rbac_cluster_roles" {
+  description = "Custom Kubernetes cluster roles to create"
+  type = map(object({
+    rules = list(object({
+      api_groups = list(string)
+      resources  = list(string)
+      verbs      = list(string)
+    }))
+  }))
+  default = {}
+}
+
 
 # Hetzner Cloud
 variable "hcloud_token" {
@@ -1424,7 +1509,6 @@ variable "ingress_load_balancer_pools" {
     error_message = "The rdns_ipv6 must be a valid IPv6 reverse DNS domain: each segment must start and end with a letter or number, can contain hyphens, and each segment must be no longer than 63 characters. Supports dynamic substitution with placeholders: {{ cluster-domain }}, {{ cluster-name }}, {{ hostname }}, {{ id }}, {{ ip-labels }}, {{ ip-type }}, {{ pool }}, {{ role }}."
   }
 }
-
 
 # Miscellaneous
 variable "prometheus_operator_crds_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -864,7 +864,7 @@ variable "talos_ccm_version" {
   description = "Specifies the version of the Talos Cloud Controller Manager (CCM) to use. This version controls cloud-specific integration features in the Talos operating system."
 }
 
-# Talos OIDC Configuration
+# Kubernetes OIDC Configuration
 variable "oidc_enabled" {
   description = "Enable OIDC authentication for Kubernetes API server"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -912,21 +912,30 @@ variable "oidc_groups_prefix" {
 }
 
 variable "oidc_group_mappings" {
-  description = "Map OIDC groups to Kubernetes roles and cluster roles"
-  type = map(object({
+  description = "List of OIDC groups mapped to Kubernetes roles and cluster roles"
+  type = list(object({
+    group         = string
     cluster_roles = optional(list(string), [])
     roles = optional(list(object({
       name      = string
       namespace = string
     })), [])
   }))
-  default = {}
+  default = []
+
+  validation {
+    condition = length(var.oidc_group_mappings) == length(distinct([
+      for mapping in var.oidc_group_mappings : mapping.group
+    ]))
+    error_message = "OIDC group names must be unique. Duplicate group names found."
+  }
 }
 
 # Kubernetes RBAC
 variable "rbac_roles" {
-  description = "Custom Kubernetes roles to create"
-  type = map(object({
+  description = "List of custom Kubernetes roles to create"
+  type = list(object({
+    name      = string
     namespace = string
     rules = list(object({
       api_groups = list(string)
@@ -934,21 +943,35 @@ variable "rbac_roles" {
       verbs      = list(string)
     }))
   }))
-  default = {}
+  default = []
+
+  validation {
+    condition = length(var.rbac_roles) == length(distinct([
+      for role in var.rbac_roles : role.name
+    ]))
+    error_message = "RBAC role names must be unique. Duplicate role names found."
+  }
 }
 
 variable "rbac_cluster_roles" {
-  description = "Custom Kubernetes cluster roles to create"
-  type = map(object({
+  description = "List of custom Kubernetes cluster roles to create"
+  type = list(object({
+    name = string
     rules = list(object({
       api_groups = list(string)
       resources  = list(string)
       verbs      = list(string)
     }))
   }))
-  default = {}
-}
+  default = []
 
+  validation {
+    condition = length(var.rbac_cluster_roles) == length(distinct([
+      for role in var.rbac_cluster_roles : role.name
+    ]))
+    error_message = "RBAC cluster role names must be unique. Duplicate cluster role names found."
+  }
+}
 
 # Hetzner Cloud
 variable "hcloud_token" {


### PR DESCRIPTION
Hi @M4t7e 👋

This PR introduces support for OIDC-based cluster auth with Kubelogin, it also allows to define ClusterRoles and Roles in the cluster and bind them to OIDC provider roles.

- Add OIDC configuration variables for Kubernetes API server authentication
- Support for external identity providers (Keycloak, Auth0, Authentik, etc.)
- Add custom RBAC roles and cluster roles creation
- Implement OIDC group to Kubernetes role bindings

I have successfully tested this with my Authentik instance. :rocket: 

Let me know if you need any adjustments or additional enhancements!
Regards!