### PR TITLE
feat(cilium): add IPSec encryption support

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -68,3 +68,23 @@ output "worker_public_ipv6_list" {
   description = "Public IPv6 addresses of all worker nodes"
   value       = local.worker_public_ipv6_list
 }
+
+output "cilium_encryption_info" {
+  description = "Information about Cilium traffic encryption"
+  value = local.cilium_ipsec_enabled ? {
+    encryption_type    = var.cilium_encryption_type
+    encryption_enabled = var.cilium_encryption_enabled
+    ipsec = {
+      current_key_id = var.cilium_ipsec_key_id
+      next_key_id    = local.cilium_key_config["next_id"]
+      algorithm      = local.cilium_ipsec_keys_manifest.metadata.annotations["cilium.io/key-algorithm"]
+      key_size_bits  = var.cilium_ipsec_key_size
+      secret_name    = local.cilium_ipsec_keys_manifest.metadata["name"]
+      namespace      = local.cilium_ipsec_keys_manifest.metadata["namespace"]
+    }
+    } : {
+    encryption_type    = var.cilium_encryption_type
+    encryption_enabled = var.cilium_encryption_enabled
+    ipsec              = {}
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1038,6 +1038,39 @@ variable "cilium_encryption_enabled" {
   description = "Enables transparent network encryption using Cilium within the Kubernetes cluster. When enabled, this feature provides added security for network traffic."
 }
 
+variable "cilium_encryption_type" {
+  type        = string
+  default     = "wireguard"
+  description = "Type of encryption to use for Cilium network encryption. Options: 'wireguard' or 'ipsec'."
+
+  validation {
+    condition     = contains(["wireguard", "ipsec"], var.cilium_encryption_type)
+    error_message = "Encryption type must be either 'wireguard' or 'ipsec'."
+  }
+}
+
+variable "cilium_ipsec_key_size" {
+  type        = number
+  default     = 256
+  description = "AES key size in bits for IPSec encryption (96, 128, or 256). Only used when cilium_encryption_type is 'ipsec'."
+
+  validation {
+    condition     = contains([96, 128, 256], var.cilium_ipsec_key_size)
+    error_message = "IPSec key size must be 96, 128 or 256 bits."
+  }
+}
+
+variable "cilium_ipsec_key_id" {
+  type        = number
+  default     = 1
+  description = "IPSec key ID (1-15, increment manually for rotation). Only used when cilium_encryption_type is 'ipsec'."
+
+  validation {
+    condition     = var.cilium_ipsec_key_id >= 1 && var.cilium_ipsec_key_id <= 15
+    error_message = "The IPSec key_id must be between 1 and 15."
+  }
+}
+
 variable "cilium_egress_gateway_enabled" {
   type        = bool
   default     = false


### PR DESCRIPTION
<p>Hi @M4t7e 👋</p>
<p>This PR adds support for <strong>IPSec</strong> as an alternative to <strong>WireGuard</strong> for Cilium network encryption.</p>
<h3>Why IPSec?</h3>
<ul>
<li>
<p>IPSec can reduce <strong>CPU overhead</strong>, especially on Hetzner VMs that support <strong>AES-NI hardware acceleration</strong>.</p>
</li>
<li>
<p>Cilium's official benchmarks highlight potential performance gains with IPSec in some scenarios:<br>
🔗 <a href="https://docs.cilium.io/en/latest/operations/performance/benchmark/#encryption-wireguard-ipsec">https://docs.cilium.io/en/latest/operations/performance/benchmark/#encryption-wireguard-ipsec</a></p>
</li>
</ul>
<h3>Summary of Changes</h3>
<ul>
<li>
<p>Adds support for choosing <strong>IPSec (AES-96,. AES-128 or AES-256)</strong> encryption mode.</p>
</li>
<li>
<p>Integrates key generation and handling directly within the module.</p>
</li>
<li>
<p>Maintains WireGuard as the default (no breaking changes).</p>
</li>
</ul>
<hr>
<h3>📊 Benchmark Results (CAX11 cluster: 3 control planes, 2 nodes)</h3>
<h4>🔁 <strong>TCP_RR – Transaction Rate (ops/sec)</strong></h4>

Scenario | Node | WireGuard | IPSec AES-128 | IPSec AES-256 | 🏆 Best
-- | -- | -- | -- | -- | --
Pod-to-Pod | Same-node | 30,992.64 | 29,743.09 | 32,920.54 | IPSec AES-256
Host-to-Host | Same-node | 29,843.24 | 29,917.69 | 29,014.37 | IPSec AES-128
Pod-to-Pod | Cross-node | 271.63 | 284.78 | 285.58 | IPSec AES-256
Host-to-Host | Cross-node | 310.11 | 301.38 | 311.17 | IPSec AES-256

<h4>⏱️ TCP_RR – Mean Latency</h4>

Scenario | Node | WireGuard | IPSec AES-128 | IPSec AES-256 | 🏆 Best
-- | -- | -- | -- | -- | --
Pod-to-Pod | Same-node | 32.01µs | 33.36µs | 30.13µs | IPSec AES-256
Host-to-Host | Same-node | 33.22µs | 33.15µs | 34.16µs | IPSec AES-128
Pod-to-Pod | Cross-node | 3.678ms | 3.508ms | 3.498ms | IPSec AES-256
Host-to-Host | Cross-node | 3.222ms | 3.315ms | 3.211ms | IPSec AES-256

<h4>📶 TCP_STREAM – Throughput (Mb/s)</h4>

Scenario | Node | Test | WireGuard | AES-128 | AES-256 | 🏆 Best
-- | -- | -- | -- | -- | -- | --
Pod-to-Pod | Same-node | STREAM | 8,429.74 | 8,419.66 | 8,146.40 | WireGuard
Pod-to-Pod | Same-node | STREAM_MULTI | 13,315.82 | 13,146.76 | 11,860.41 | WireGuard
Host-to-Host | Same-node | STREAM | 20,763.38 | 20,747.28 | 20,513.05 | WireGuard
Host-to-Host | Same-node | STREAM_MULTI | 27,882.39 | 27,230.18 | 27,302.51 | WireGuard
Pod-to-Pod | Cross-node | STREAM | 918.98 | 1,053.13 | 1,056.87 | IPSec AES-256
Pod-to-Pod | Cross-node | STREAM_MULTI | 1,657.18 | 1,609.21 | 1,567.97 | WireGuard
Host-to-Host | Cross-node | STREAM | 3,259.56 | 3,149.77 | 3,232.01 | WireGuard
Host-to-Host | Cross-node | STREAM_MULTI | 4,084.45 | 4,253.60 | 4,723.44 | IPSec AES-256


<p>Let me know if you'd like any further adjustments or testing details!<br>
Regards !</p>