### PR TITLE
Integrate Netkit for high-performance Pod Networking

### DIFF
--- a/cilium.tf
+++ b/cilium.tf
@@ -40,11 +40,10 @@ data "helm_template" "cilium" {
       name  = "bpf.masquerade"
       value = true
     },
-    # Netkit requires kernel >= 6.8
-    # {
-    #   name  = "bpf.datapathMode"
-    #   value = "netkit"
-    # },
+    {
+      name  = "bpf.datapathMode"
+      value = "netkit"
+    },
     {
       name  = "loadBalancer.acceleration"
       value = "native"


### PR DESCRIPTION
This PR adds support for Netkit in Cilium. Netkit is a new high-performance container network device that replaces traditional veth interfaces. It uses paired eBPF programs to reduce latency and CPU overhead, offering near host-level networking performance.
 
See: https://isovalent.com/blog/post/cilium-netkit-a-new-container-networking-paradigm-for-the-ai-era/#shortcut-4-introducing-netkit

To apply the change immediately:
```shell
kubectl -n kube-system rollout restart daemonset cilium
kubectl -n kube-system rollout status daemonset cilium
```

Verify that Netkit is active:
```shell
kubectl exec -n kube-system -it daemonsets/cilium -- cilium status | grep "Device Mode"
Device Mode:             netkit
```