### PR TITLE
fix: check on hcloud_floating_ip id when floating_ip id is provided by variable

### DIFF
--- a/floating_ip.tf
+++ b/floating_ip.tf
@@ -27,6 +27,6 @@ data "hcloud_floating_ip" "control_plane_ipv4" {
 
   id = coalesce(
     can(var.control_plane_public_vip_ipv4_id) ? var.control_plane_public_vip_ipv4_id : null,
-    local.control_plane_public_vip_ipv4_enabled ? hcloud_floating_ip.control_plane_ipv4[0].id : null
+    local.control_plane_public_vip_ipv4_enabled ? try(hcloud_floating_ip.control_plane_ipv4[0].id, null) : null
   )
 }


### PR DESCRIPTION
Fixes an issue, when floating ip id is provided by var.control_plane_public_vip_ipv4_id

In such a case, the `hcloud_floating_ip.control_plane_ipv4` is an empty tuple and the check on resource fails, as `local.control_plane_public_vip_ipv4_enabled` is `true`, in both cases (configure floating ip via bool switch / provide the floating ip from outside 