### PR TITLE
Workaround for empty Hcloud API userdata

### DIFF
--- a/server.tf
+++ b/server.tf
@@ -28,6 +28,7 @@ resource "hcloud_server" "control_plane" {
   shutdown_before_deletion = true
   delete_protection        = var.cluster_delete_protection
   rebuild_protection       = var.cluster_delete_protection
+  user_data                = data.talos_machine_configuration.control_plane_init.machine_configuration
 
   labels = merge(
     each.value.labels,
@@ -60,6 +61,7 @@ resource "hcloud_server" "control_plane" {
   lifecycle {
     ignore_changes = [
       image,
+      user_data,
       network,
       ssh_keys
     ]
@@ -93,6 +95,7 @@ resource "hcloud_server" "worker" {
   shutdown_before_deletion = true
   delete_protection        = var.cluster_delete_protection
   rebuild_protection       = var.cluster_delete_protection
+  user_data                = data.talos_machine_configuration.worker_init.machine_configuration
 
   labels = merge(
     each.value.labels,
@@ -125,6 +128,7 @@ resource "hcloud_server" "worker" {
   lifecycle {
     ignore_changes = [
       image,
+      user_data,
       ssh_keys
     ]
   }


### PR DESCRIPTION
Workaround for #171

Talos doesn’t appear to handle empty HTTP responses (HTTP 204 status code), which seem to have been introduced recently in the Hetzner Cloud API. This PR ensures that `userdata` is always provided. Waiting for a final fix in Talos would likely take too long.