### PR TITLE
Workaround for empty Hcloud API userdata in NAT GW setup

### DIFF
--- a/cilium.tf
+++ b/cilium.tf
@@ -152,6 +152,8 @@ data "helm_template" "cilium" {
         ui      = { enabled = var.cilium_hubble_ui_enabled }
       }
       operator = {
+        nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
+        tolerations  = [{ operator = "Exists" }]
         prometheus = {
           enabled = true
           serviceMonitor = {

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -520,12 +520,21 @@ locals {
         extraKernelArgs = var.talos_extra_kernel_args
       }
       network = {
-        interfaces = [
-          {
+        interfaces = concat(
+          local.talos_public_interface_enabled ? [{
             interface = "eth0"
             dhcp      = true
-          }
-        ]
+            dhcpOptions = {
+              ipv4 = var.talos_public_ipv4_enabled
+              ipv6 = false
+            }
+          }] : [],
+          [{
+            interface = local.talos_public_interface_enabled ? "eth1" : "eth0"
+            dhcp      = true
+            routes    = local.talos_extra_routes
+          }]
+        )
         nameservers = local.talos_nameservers
       }
       kernel = {


### PR DESCRIPTION
Extended workaround for #171

This PR extends the workaround from #172 to support NAT gateway setups. The only exception is Cluster Autoscaler, which can't be addressed in a NAT gateway scenario, as Talos attempts to request its IP address from the Hetzner Cloud API, which also returns a 204 response in this case.