### PR TITLE
Add support for config patches during initial machine creation

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -562,7 +562,10 @@ data "talos_machine_configuration" "control_plane_init" {
   docs               = false
   examples           = false
 
-  config_patches = [yamlencode(local.talos_init_config)]
+  config_patches = concat(
+    [yamlencode(local.talos_init_config)],
+    [for patch in var.control_plane_init_config_patches : yamlencode(patch)]
+  )
 }
 
 data "talos_machine_configuration" "worker_init" {
@@ -575,7 +578,10 @@ data "talos_machine_configuration" "worker_init" {
   docs               = false
   examples           = false
 
-  config_patches = [yamlencode(local.talos_init_config)]
+  config_patches = concat(
+    [yamlencode(local.talos_init_config)],
+    [for patch in var.worker_init_config_patches : yamlencode(patch)]
+  )
 }
 
 data "talos_machine_configuration" "control_plane" {

--- a/variables.tf
+++ b/variables.tf
@@ -327,6 +327,11 @@ variable "control_plane_config_patches" {
   description = "List of configuration patches applied to the Control Plane nodes."
 }
 
+variable "control_plane_init_config_patches" {
+  type        = any
+  default     = []
+  description = "List of configuration patches applied to the Control Plane nodes when first initializing."
+}
 
 # Worker
 variable "worker_nodepools" {
@@ -405,6 +410,11 @@ variable "worker_config_patches" {
   description = "List of configuration patches applied to the Worker nodes."
 }
 
+variable "worker_init_config_patches" {
+  type        = any
+  default     = []
+  description = "List of configuration patches applied to the Worker nodes when initializing."
+}
 
 # Cluster Autoscaler
 variable "cluster_autoscaler_helm_repository" {


### PR DESCRIPTION
Enables applying configuration patches during machine creation which, most notably, allows using VolumeConfig resources to modify system volumes. 
Relevant to #79.