### PR TITLE
Ensure packer init is always applied

### DIFF
--- a/image.tf
+++ b/image.tf
@@ -102,7 +102,12 @@ data "hcloud_images" "arm64" {
 }
 
 resource "terraform_data" "packer_init" {
-  triggers_replace = ["${sha1(file("${path.module}/packer/requirements.pkr.hcl"))}"]
+  triggers_replace = [
+    "${sha1(file("${path.module}/packer/requirements.pkr.hcl"))}",
+    var.cluster_name,
+    var.talos_version,
+    local.talos_schematic_id
+  ]
 
   provisioner "local-exec" {
     when        = create


### PR DESCRIPTION
This PR ensures that packer init is always run first again when the module is used on a different system with the same TF state and an image build is required.