### PR TITLE
Add Support for Cluster Autoscaler Upgrades and Configuration Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,20 @@ cluster_autoscaler_helm_values = {
   }
 }
 ```
+
+##### Talos Upgrades and Configuration Changes
+Cluster Autoscaler does not support upgrading nodes or changing their configuration, as its primary purpose is to manage short-lived nodes that handle load peaks. If you require long-lived autoscaled nodes, you can upgrade them manually using `talosctl` or use this Terraform module, which supports discovery of autoscaled nodes and manages their upgrades and configuration changes.
+
+To enable this feature, install [jq](https://jqlang.org/download/) and add the following to your configuration:
+```hcl
+cluster_autoscaler_discovery_enabled = true
+```
+
+Please note that errors may occur if a node pool has been scaled down recently, as Talos caches absent nodes for up to [30 minutes](https://www.talos.dev/latest/introduction/troubleshooting/#removed-members-are-still-present). You can pause automatic scaling by stopping the Cluster Autoscaler pods:
+```sh
+kubectl -n kube-system scale deployment cluster-autoscaler-hetzner-cluster-autoscaler --replicas=0
+```
+
 </details>
 
 

--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -1,5 +1,6 @@
 locals {
-  cluster_autoscaler_enabled = length(local.cluster_autoscaler_nodepools) > 0
+  cluster_autoscaler_enabled          = length(local.cluster_autoscaler_nodepools) > 0
+  cluster_autoscaler_hostname_pattern = "^${var.cluster_name}-(${join("|", distinct([for np in local.cluster_autoscaler_nodepools : np.name]))})-[0-9a-f]+$"
 
   cluster_autoscaler_release_name       = "cluster-autoscaler"
   cluster_autoscaler_cloud_provider     = "hetzner"

--- a/client.tf
+++ b/client.tf
@@ -41,7 +41,7 @@ resource "terraform_data" "create_talosconfig" {
   count = var.cluster_talosconfig_path != null ? 1 : 0
 
   triggers_replace = [
-    sha1(local.talosconfig),
+    nonsensitive(sha1(local.talosconfig)),
     var.cluster_talosconfig_path
   ]
 
@@ -86,7 +86,7 @@ resource "terraform_data" "create_kubeconfig" {
   count = var.cluster_kubeconfig_path != null ? 1 : 0
 
   triggers_replace = [
-    sha1(local.kubeconfig),
+    nonsensitive(sha1(local.kubeconfig)),
     var.cluster_kubeconfig_path
   ]
 

--- a/network.tf
+++ b/network.tf
@@ -23,20 +23,23 @@ locals {
   )
 
   # Lists for control plane nodes
-  control_plane_public_ipv4_list        = [for server in hcloud_server.control_plane : server.ipv4_address]
-  control_plane_public_ipv6_list        = [for server in hcloud_server.control_plane : server.ipv6_address]
-  control_plane_public_ipv6_subnet_list = [for server in hcloud_server.control_plane : server.ipv6_network]
-  control_plane_private_ipv4_list       = [for server in hcloud_server.control_plane : tolist(server.network)[0].ip]
+  control_plane_public_ipv4_list  = compact(distinct([for server in hcloud_server.control_plane : server.ipv4_address]))
+  control_plane_public_ipv6_list  = compact(distinct([for server in hcloud_server.control_plane : server.ipv6_address]))
+  control_plane_private_ipv4_list = compact(distinct([for server in hcloud_server.control_plane : tolist(server.network)[0].ip]))
 
   # Control plane VIPs
   control_plane_public_vip_ipv4  = local.control_plane_public_vip_ipv4_enabled ? data.hcloud_floating_ip.control_plane_ipv4[0].ip_address : null
   control_plane_private_vip_ipv4 = cidrhost(hcloud_network_subnet.control_plane.ip_range, -2)
 
   # Lists for worker nodes
-  worker_public_ipv4_list        = [for server in hcloud_server.worker : server.ipv4_address]
-  worker_public_ipv6_list        = [for server in hcloud_server.worker : server.ipv6_address]
-  worker_public_ipv6_subnet_list = [for server in hcloud_server.worker : server.ipv6_network]
-  worker_private_ipv4_list       = [for server in hcloud_server.worker : tolist(server.network)[0].ip]
+  worker_public_ipv4_list  = compact(distinct([for server in hcloud_server.worker : server.ipv4_address]))
+  worker_public_ipv6_list  = compact(distinct([for server in hcloud_server.worker : server.ipv6_address]))
+  worker_private_ipv4_list = compact(distinct([for server in hcloud_server.worker : tolist(server.network)[0].ip]))
+
+  # Lists for cluster autoscaler nodes
+  cluster_autoscaler_public_ipv4_list  = compact(distinct([for server in local.cluster_autoscaler_server : server.public_ipv4_address]))
+  cluster_autoscaler_public_ipv6_list  = compact(distinct([for server in local.cluster_autoscaler_server : server.public_ipv6_address]))
+  cluster_autoscaler_private_ipv4_list = compact(distinct([for server in local.cluster_autoscaler_server : server.private_ipv4_address]))
 }
 
 data "hcloud_location" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -489,6 +489,12 @@ variable "cluster_autoscaler_config_patches" {
   description = "List of configuration patches applied to the Cluster Autoscaler nodes."
 }
 
+variable "cluster_autoscaler_discovery_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable rolling upgrades of Cluster Autoscaler nodes during Talos OS upgrades and Talos configuration changes. This feature requires jq to be installed on the machine running Terraform."
+}
+
 
 # Packer
 variable "packer_amd64_builder" {


### PR DESCRIPTION
This PR adds optional support for automatic discovery and rolling upgrade of autoscaled nodes managed by the Cluster Autoscaler, including configuration changes.