### PR TITLE
Add talosctl minimum version check

### DIFF
--- a/client.tf
+++ b/client.tf
@@ -126,3 +126,34 @@ resource "terraform_data" "create_kubeconfig" {
 
   depends_on = [talos_machine_configuration_apply.control_plane]
 }
+
+data "external" "talosctl_version_check" {
+  program = [
+    "sh", "-c", <<-EOT
+      set -eu
+
+      parsed_version=$(
+        talosctl version --client --short | while IFS= read -r line; do
+          case $line in
+            *[vV][0-9]*.[0-9]*.[0-9]*)
+              v=$${line##*[vV]}; maj=$${v%%.*}; r=$${v#*.}; min=$${r%%.*}; patch=$${r#*.}
+              printf '%s %s %s\n' "$maj" "$min" "$patch"; break
+              ;;
+          esac
+        done
+      )
+      [ -n "$parsed_version" ] || { echo "Could not parse talosctl client version" >&2; exit 1; }
+
+      set -- $parsed_version; major=$1; minor=$2; patch=$3
+      if [ "$major" -lt "${local.talos_version_major}" ] ||
+        { [ "$major" -eq "${local.talos_version_major}" ] && [ "$minor" -lt "${local.talos_version_minor}" ]; } ||
+        { [ "$major" -eq "${local.talos_version_major}" ] && [ "$minor" -eq "${local.talos_version_minor}" ] && [ "$patch" -lt "${local.talos_version_patch}" ]; }
+      then
+        echo "talosctl version ($major.$minor.$patch) is lower than Talos target version: ${local.talos_version_major}.${local.talos_version_minor}.${local.talos_version_patch}" >&2
+        exit 1
+      fi
+
+      echo "{\"talosctl_version\": \"$major.$minor.$patch\"}"
+    EOT
+  ]
+}

--- a/server.tf
+++ b/server.tf
@@ -216,6 +216,7 @@ data "external" "talos_members" {
   }
 
   depends_on = [
+    data.external.talosctl_version_check,
     terraform_data.upgrade_control_plane,
     terraform_data.upgrade_worker
   ]


### PR DESCRIPTION
This PR implements the following request:
> Would it be possible to add a version check in your bootstrap and fail if smaller than server version? My `talosctl` comes from homebrew and it hasn't auto updated for a while... 

 _Originally posted by @ViRb3 in [#207](https://github.com/hcloud-k8s/terraform-hcloud-kubernetes/issues/207#issuecomment-3405948001)_