### PR TITLE
feat: add renovate rules for Talos/K8s and update k8s,talos,talos-backup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,15 @@
         "major"
       ],
       "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Pin Kubernetes & Talos to current minor and update only patch releases",
+      "matchDatasources": ["github-tags"],
+      "matchDepNames": [
+        "kubernetes/kubernetes",
+        "siderolabs/talos"
+      ],
+      "matchUpdateTypes": ["patch"]
     }
   ],
   "customManagers": [

--- a/talos_backup.tf
+++ b/talos_backup.tf
@@ -62,7 +62,8 @@ locals {
                   { name = "BUCKET", value = local.talos_backup_s3_bucket },
                   { name = "CLUSTER_NAME", value = var.cluster_name },
                   { name = "S3_PREFIX", value = var.talos_backup_s3_prefix },
-                  { name = "USE_PATH_STYLE", value = tostring(var.talos_backup_s3_path_style) }
+                  { name = "USE_PATH_STYLE", value = tostring(var.talos_backup_s3_path_style) },
+                  { name = "ENABLE_COMPRESSION", value = tostring(var.talos_backup_enable_compression) }
                 ]
                 volumeMounts = [
                   { name = "tmp", mountPath = "/tmp" },

--- a/variables.tf
+++ b/variables.tf
@@ -533,7 +533,7 @@ variable "packer_arm64_builder" {
 # Talos
 variable "talos_version" {
   type        = string
-  default     = "v1.11.1"
+  default     = "v1.11.3" # https://github.com/siderolabs/talos
   description = "Specifies the version of Talos to be used in generated machine configurations."
 }
 
@@ -738,7 +738,7 @@ variable "talos_extra_remote_manifests" {
 # Talos Backup
 variable "talos_backup_version" {
   type        = string
-  default     = "v0.1.0-beta.2-1-g9ccc125"
+  default     = "v0.1.0-beta.3-3-g38dad7c"
   description = "Specifies the version of Talos Backup to be used in generated machine configurations."
 }
 
@@ -804,6 +804,12 @@ variable "talos_backup_age_x25519_public_key" {
   description = "AGE X25519 Public Key for client side Talos Backup encryption."
 }
 
+variable "talos_backup_enable_compression" {
+  type        = bool
+  default     = false
+  description = "Enable ETCD snapshot compression with zstd algorithm."
+}
+
 variable "talos_backup_schedule" {
   type        = string
   default     = "0 * * * *"
@@ -814,7 +820,7 @@ variable "talos_backup_schedule" {
 # Kubernetes
 variable "kubernetes_version" {
   type        = string
-  default     = "v1.33.4"
+  default     = "v1.33.5" # https://github.com/kubernetes/kubernetes
   description = "Specifies the Kubernetes version to deploy."
 }
 


### PR DESCRIPTION
Hi @M4t7e! :grin:  Hope everything is going well.

This PR includes two main changes:

- Talos backup updated to the latest release, including optional ZSTD snapshot compression.
- Renovate configuration improved to detect Kubernetes and Talos versions defined in Terraform, restricting updates to patch releases only.

With this in place, now that we’re on Talos v1.11.x, Renovate will notify us whenever a new minor Talos patch is available, same for k8s minors.

Regards! :rocket: 