### PR TITLE
feat(autoscaler): allocate dedicated subnets for autoscaled nodepools

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -23,9 +23,10 @@ locals {
           },
           nodeConfigs = {
             for nodepool in local.cluster_autoscaler_nodepools : "${var.cluster_name}-${nodepool.name}" => {
-              cloudInit = data.talos_machine_configuration.cluster_autoscaler[nodepool.name].machine_configuration,
-              labels    = nodepool.labels
-              taints    = nodepool.taints
+              cloudInit     = data.talos_machine_configuration.cluster_autoscaler[nodepool.name].machine_configuration,
+              labels        = nodepool.labels
+              taints        = nodepool.taints
+              subnetIPRange = hcloud_network_subnet.autoscaler[nodepool.name].ip_range,
             }
           }
         }
@@ -91,7 +92,7 @@ data "helm_template" "cluster_autoscaler" {
         HCLOUD_SSH_KEY                 = tostring(hcloud_ssh_key.this.id)
         HCLOUD_PUBLIC_IPV4             = tostring(var.talos_public_ipv4_enabled)
         HCLOUD_PUBLIC_IPV6             = tostring(var.talos_public_ipv6_enabled)
-        HCLOUD_NETWORK                 = tostring(hcloud_network_subnet.autoscaler.network_id)
+        HCLOUD_NETWORK                 = tostring(local.hcloud_network_id)
       }
       extraEnvSecrets = {
         HCLOUD_TOKEN = {

--- a/network.tf
+++ b/network.tf
@@ -103,6 +103,8 @@ resource "hcloud_network_subnet" "worker" {
 }
 
 resource "hcloud_network_subnet" "autoscaler" {
+  for_each = { for np in local.cluster_autoscaler_nodepools : np.name => np }
+
   network_id   = local.hcloud_network_id
   type         = "cloud"
   network_zone = local.hcloud_network_zone
@@ -110,7 +112,7 @@ resource "hcloud_network_subnet" "autoscaler" {
   ip_range = cidrsubnet(
     local.network_node_ipv4_cidr,
     local.network_node_ipv4_subnet_mask_size - split("/", local.network_node_ipv4_cidr)[1],
-    pow(2, local.network_node_ipv4_subnet_mask_size - split("/", local.network_node_ipv4_cidr)[1]) - 1
+    pow(2, local.network_node_ipv4_subnet_mask_size - split("/", local.network_node_ipv4_cidr)[1]) - 1 - index(local.cluster_autoscaler_nodepools, each.value)
   )
 
   depends_on = [


### PR DESCRIPTION
Hi @M4t7e! :smile:

This PR lays the groundwork for https://github.com/kubernetes/autoscaler/pull/8570
When the new cluster-autoscaler version lands, autoscaled nodes will be able to use their own subnet instead of sharing space with workers.

While the current layout makes overlaps unlikely, once autoscaled nodepools exist and new worker pools are added the ranges can eventually collide. To eliminate that risk, this PR allocates autoscaler subnets in the opposite direction (from the top of the quarter downward), giving them a dedicated, future-proof space.

This is fully backwards-compatible: it does not change current autoscaler behavior and only recreates the autoscaler subnets, with no other impact on existing deployments.

Partly fixes #163