### PR TITLE
Add variable to allow scheduling on control planes

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -1,5 +1,5 @@
 locals {
-  talos_allow_scheduling_on_control_planes = ((local.worker_sum + local.cluster_autoscaler_max_sum) == 0)
+  talos_allow_scheduling_on_control_planes = coalesce(var.cluster_allow_scheduling_on_control_planes, (local.worker_sum + local.cluster_autoscaler_max_sum) == 0)
 
   kube_oidc_configuration = var.oidc_enabled ? {
     "oidc-issuer-url"     = var.oidc_issuer_url

--- a/variables.tf
+++ b/variables.tf
@@ -94,6 +94,12 @@ variable "cluster_delete_protection" {
   description = "Adds delete protection for resources that support it."
 }
 
+variable "cluster_allow_scheduling_on_control_planes" {
+  type        = bool
+  default     = null
+  description = "Allow scheduling on control plane nodes. If this is false, scheduling on control plane nodes is explicitly disabled. Defaults to true if there are no workers present."
+}
+
 
 # Client Tools
 variable "client_prerequisites_check_enabled" {


### PR DESCRIPTION
I found out that there is no way to enable scheduling on control planes. This is an option that I wanted for creating a small but HA cluster.

Let me know if I need to add further documentation, I couldn't find a suitable spot in the readme for this.