### PR TITLE
Update server locations from `fsn1` to `nbg1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ module "kubernetes" {
   cilium_gateway_api_enabled = true
 
   control_plane_nodepools = [
-    { name = "control", type = "cpx22", location = "fsn1", count = 3 }
+    { name = "control", type = "cpx22", location = "nbg1", count = 3 }
   ]
   worker_nodepools = [
-    { name = "worker", type = "cpx22", location = "fsn1", count = 3 }
+    { name = "worker", type = "cpx22", location = "nbg1", count = 3 }
   ]
 }
 ```
@@ -347,7 +347,7 @@ cluster_autoscaler_nodepools = [
   {
     name     = "autoscaler"
     type     = "cpx22"
-    location = "fsn1"
+    location = "nbg1"
     min      = 0
     max      = 6
     labels   = { "autoscaler-node" = "true" }
@@ -443,7 +443,7 @@ worker_nodepools = [
   {
     name     = "egress"
     type     = "cpx22"
-    location = "fsn1"
+    location = "nbg1"
     labels   = { "egress-node" = "true" }
     taints   = [ "egress-node=true:NoSchedule" ]
   }
@@ -586,8 +586,8 @@ spec:
   gatewayClassName: cilium
   infrastructure:
     annotations:
-      load-balancer.hetzner.cloud/name: "cilium-gateway-fsn1"
-      load-balancer.hetzner.cloud/location: "fsn1"
+      load-balancer.hetzner.cloud/name: "cilium-gateway-nbg1"
+      load-balancer.hetzner.cloud/location: "nbg1"
       load-balancer.hetzner.cloud/uses-proxyprotocol: "true"
   listeners:
     - name: https
@@ -918,7 +918,7 @@ cluster_autoscaler_nodepools = [
   {
     name     = "autoscaler"
     type     = "cpx22"
-    location = "fsn1"
+    location = "nbg1"
     min      = 0
     max      = 6
     labels   = {

--- a/variables.tf
+++ b/variables.tf
@@ -559,7 +559,7 @@ variable "packer_amd64_builder" {
 variable "packer_arm64_builder" {
   type = object({
     server_type     = optional(string, "cax11")
-    server_location = optional(string, "fsn1")
+    server_location = optional(string, "nbg1")
   })
   default     = {}
   description = "Configuration for the server used when building the Talos ARM64 image with Packer."


### PR DESCRIPTION
The `fsn1` location is temporarily unavailable due to limited cloud server capacity.

See: https://status.hetzner.com/incident/0a75c7ae-3377-41dc-aabe-601063724d24