### PR TITLE
Trigger Talos config reapply on node replacement

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -162,7 +162,8 @@ locals {
         }
         nodeLabels = merge(
           local.talos_allow_scheduling_on_control_planes ? { "node.kubernetes.io/exclude-from-external-load-balancers" = { "$patch" = "delete" } } : {},
-          local.control_plane_nodepools_map[node.labels.nodepool].labels
+          local.control_plane_nodepools_map[node.labels.nodepool].labels,
+          { "nodeid" = tostring(node.id) }
         )
         nodeAnnotations = local.control_plane_nodepools_map[node.labels.nodepool].annotations
         nodeTaints = {
@@ -325,7 +326,10 @@ locals {
           image           = local.talos_installer_image_url
           extraKernelArgs = var.talos_extra_kernel_args
         }
-        nodeLabels      = local.worker_nodepools_map[node.labels.nodepool].labels
+        nodeLabels = merge(
+          local.worker_nodepools_map[node.labels.nodepool].labels,
+          { "nodeid" = tostring(node.id) }
+        )
         nodeAnnotations = local.worker_nodepools_map[node.labels.nodepool].annotations
         certSANs        = local.certificate_san
         network = {


### PR DESCRIPTION
Previously, when a node was manually deleted (via Hetzner Console, API, etc.) or recreated using `tofu taint`, the `talos_machine_configuration_apply` resource had to be manually triggered by deleting it from the state with `tofu state rm` to reapply the Talos configuration. This was necessary because by default the configuration is only reapplied if it changes, which does not happen when simply replacing a node.

This PR improves the node recreation process by adding the Hetzner Cloud server ID to the node labels. Whenever a server is replaced, a configuration change is triggered and the Talos configuration is reliably reapplied.