### PR TITLE
Refactor talosctl command setup and usage

### DIFF
--- a/templates/talos_apply_config.sh.tftpl
+++ b/templates/talos_apply_config.sh.tftpl
@@ -1,0 +1,21 @@
+set -- ${join(" ", target_nodes)}
+for host in "$@"; do
+  (
+    set -eu
+
+    machine_config=$(mktemp)
+    cleanup() { rm -f "$machine_config"; }
+    trap 'cleanup' EXIT
+    trap 'cleanup; exit 1' HUP INT TERM QUIT PIPE
+
+    printf '%s\n' "Applying machine configuration to node: $host"
+    envname="TALOS_MC_$(printf '%s' "$host" | tr . _)"
+    eval "machine_config_value=\$$envname"
+    printf '%s' "$machine_config_value" > "$machine_config"
+
+    retry=1
+    until talos_apply_config --nodes "$host" --file "$machine_config"; do
+      talos_retry_or_exit retry
+    done
+  )
+done

--- a/templates/talos_upgrade.sh.tftpl
+++ b/templates/talos_upgrade.sh.tftpl
@@ -1,0 +1,42 @@
+talos_wait_for_health
+
+set -- ${join(" ", upgrade_nodes)}
+for host in "$@"; do
+  retry=1
+  while true; do
+    printf '%s\n' "Checking node $host ..."
+
+    current_version=$(talos_get_version --nodes "$host")
+    current_schematic=$(talos_get_schematic --nodes "$host")
+
+    if [ "$current_version" = "${talos_version}" ] && [ "$current_schematic" = "${talos_schematic_id}" ]; then
+      if [ "$retry" -gt 1 ]; then
+        printf '%s\n' "Node $host is already at Talos $current_version ($current_schematic). Waiting for cluster to stabilize ..."
+        sleep 5
+
+        talos_wait_for_health
+        printf '%s\n' "Node $host upgraded successfully"
+      else
+        printf '%s\n' "Node $host is already at Talos $current_version ($current_schematic). Skipping upgrade ..."
+      fi
+
+      break
+    elif [ -n "$current_version" ] && [ -n "$current_schematic" ]; then
+      printf '%s\n' "Node $host is currently at Talos $current_version ($current_schematic)"
+    else
+      printf '%s\n' "Could not determine current Talos version or schematic for node $host"
+    fi
+
+    printf '%s\n' "Upgrading node $host to Talos ${talos_version} (${talos_schematic_id}) ..."
+    if talos_upgrade --nodes "$host"; then
+      printf '%s\n' "Upgrade successfully completed for node $host"
+      sleep 5
+
+      talos_wait_for_health
+      printf '%s\n' "Node $host upgraded successfully"
+      break
+    fi
+
+    talos_retry_or_exit retry
+  done
+done

--- a/templates/talos_upgrade_k8s.sh.tftpl
+++ b/templates/talos_upgrade_k8s.sh.tftpl
@@ -1,0 +1,9 @@
+talos_wait_for_health
+
+retry=1
+until talos_upgrade_k8s; do
+  talos_retry_or_exit retry
+done
+sleep 5
+
+talos_wait_for_health

--- a/templates/talosctl_commands.sh.tftpl
+++ b/templates/talosctl_commands.sh.tftpl
@@ -1,0 +1,195 @@
+
+talosconfig=$(mktemp)
+cleanup() { rm -f "$talosconfig"; }
+trap 'cleanup' EXIT
+trap 'cleanup; exit 1' HUP INT TERM QUIT PIPE
+
+printf '%s' "$TALOSCONFIG" > "$talosconfig"
+
+talos_retry_or_exit() {
+  retry_var=$1
+  eval "retry_value=\$$retry_var"
+
+  if [ "$retry_value" -gt "${talosctl_retries}" ]; then
+    exit 1
+  fi
+
+  printf '%s\n' "Retry $retry_value/${talosctl_retries} ..."
+  retry_value=$((retry_value + 1))
+  eval "$retry_var=$retry_value"
+  sleep 10
+}
+
+talos_health_check() {
+  if ! ${healthcheck_enabled}; then
+    return 0
+  fi
+
+  talosctl health \
+    --talosconfig "$talosconfig" \
+    --server=true \
+    --control-plane-nodes '${join(",", control_plane_nodes)}' \
+    --worker-nodes '${join(",", worker_nodes)}' \
+    --nodes "${talos_primary_node}" \
+    "$@"
+}
+
+talos_wait_for_health() {
+  health_retry=1
+  until talos_health_check; do
+    talos_retry_or_exit health_retry
+  done
+}
+
+talos_upgrade() {
+  talosctl upgrade \
+    --talosconfig "$talosconfig" \
+%{ if talos_upgrade_debug ~}
+    --debug \
+%{ endif ~}
+%{ if talos_upgrade_force ~}
+    --force \
+%{ endif ~}
+%{ if talos_upgrade_insecure ~}
+    --insecure \
+%{ endif ~}
+%{ if talos_upgrade_stage ~}
+    --stage \
+%{ endif ~}
+%{ if talos_upgrade_reboot_mode != null ~}
+    --reboot-mode '${talos_upgrade_reboot_mode}' \
+%{ endif ~}
+    --image '${talos_installer_image_url}' \
+    "$@"
+}
+
+talos_apply_config() {
+  talosctl apply-config \
+    --talosconfig "$talosconfig" \
+    "$@"
+}
+
+talos_upgrade_k8s() {
+  awk -v talosconfig="$talosconfig" '
+    function indent(s) { return match(s, /[^[:space:]]/) ? RSTART - 1 : 0 }
+    function out(s)    { print s; fflush() }
+    function redact(s) { sub(/:[[:space:]]*.*/, ": <REDACTED>", s); return s }
+
+    BEGIN {
+      sq = sprintf("%c", 39)
+      us = sprintf("%c", 31)
+
+      secret_re              = "\\.[Ss]ecrets?/"
+      allowed_secret_keys_re = "^(apiVersion|kind|name|namespace|type)$"
+
+      # Build talosctl command and append exit-code marker line
+      run = "talosctl upgrade-k8s"
+      run = run " --talosconfig " sq talosconfig sq
+      run = run " --nodes "       sq "${talos_primary_node}" sq
+      run = run " --endpoint "    sq "${kube_api_url}" sq
+      run = run " --to "          sq "${kubernetes_version}" sq
+      run = run " --with-docs=false --with-examples=false"
+      run = run " ; printf " sq "\\037RC=%d\\n" sq " $?"
+
+      in_secret  = 0
+      drop_block = 0
+
+      while ((run | getline line) > 0) {
+        # Exit code passthrough
+        if (index(line, us "RC=") == 1) {
+          exit substr(line, 5) + 0
+        }
+
+        # If we redacted a block scalar header, skip its indented body
+        if (drop_block) {
+          t = line
+          sub(/^[+- ]/, "", t)
+          if (indent(t) > block_indent) continue
+          drop_block = 0
+        }
+
+        # Detect Secret context from talosctl progress lines
+        if (line ~ /^[[:space:]]*>[[:space:]]*processing[[:space:]]+manifest/) {
+          in_secret = (line ~ secret_re)
+          out(line)
+          continue
+        }
+
+        # Detect Secret context from unified diff headers
+        if (line ~ /^[[:space:]]*(---[[:space:]]+a\/|\+\+\+[[:space:]]+b\/)/) {
+          if (line ~ secret_re) {
+            in_secret = 1
+          }
+          out(line)
+          continue
+        }
+
+        # Outside Secret => passthrough unchanged
+        if (!in_secret) {
+          out(line)
+          continue
+        }
+
+        # Inside Secret => parse YAML-ish "key: value"
+        yaml_line = line
+        sub(/^[+- ]/, "", yaml_line)
+        parse_line = yaml_line
+        sub(/^[[:space:]]*-[[:space:]]+/, "", parse_line)
+        colon_pos = index(parse_line, ":")
+
+        if (!colon_pos) {
+          out(line)
+          continue
+        }
+
+        # Split into key and value
+        key = substr(parse_line, 1, colon_pos - 1)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+
+        value = substr(parse_line, colon_pos + 1)
+        sub(/^[[:space:]]+/, "", value)
+
+        # No value on this line
+        if (value == "") {
+          out(line)
+          continue
+        }
+
+        # Block scalar header
+        if (value ~ /^[|>]/) {
+          out(redact(line))
+          drop_block   = 1
+          block_indent = indent(yaml_line)
+          continue
+        }
+
+        # Redact non-allowed keys
+        if (key ~ allowed_secret_keys_re) {
+          out(line)
+        } else {
+          out(redact(line))
+          continue
+        }
+      }
+
+      exit 1
+    }
+  '
+}
+
+talos_get_version() {
+  talosctl get version \
+    --talosconfig "$talosconfig" \
+    --output jsonpath='{.spec.version}' \
+    "$@" \
+    2>/dev/null || true
+}
+
+talos_get_schematic() {
+  talosctl get extensions \
+    --talosconfig "$talosconfig" \
+    --output json \
+    "$@" \
+    | jq -r 'select(.spec.metadata.name=="schematic") | .spec.metadata.version' \
+    2>/dev/null || true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -114,14 +114,14 @@ variable "talosctl_version_check_enabled" {
   description = "Controls whether a preflight check verifies the local talosctl client version before provisioning."
 }
 
-variable "talosctl_retry_count" {
+variable "talosctl_retries" {
   type        = number
-  default     = 5
+  default     = 10
   description = "Specifies how many times talosctl operations should retry before failing. This setting helps improve resilience against transient network issues or temporary API unavailability."
 
   validation {
-    condition     = var.talosctl_retry_count >= 0
-    error_message = "The talosctl retry count must be at least 0."
+    condition     = var.talosctl_retries >= 0
+    error_message = "The talosctl retries value must be at least 0."
   }
 }
 


### PR DESCRIPTION
This PR centralizes `talosctl` command setup into a shared template, streamlines upgrade/apply flows to reuse it, and standardizes retries and health checks. It also redacts `talosctl upgrade-k8s` diff output secrets to avoid leaking sensitive data.