### PR TITLE
Add Hetzner DNS zone + external-dns wiring

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,6 @@
+resource "hcloud_zone" "this" {
+  count = var.dns_zone_create ? 1 : 0
+
+  name = var.dns_zone_name
+  mode = "primary"
+}

--- a/external_dns.tf
+++ b/external_dns.tf
@@ -1,0 +1,106 @@
+locals {
+  external_dns_namespace = var.external_dns.enabled ? {
+    apiVersion = "v1"
+    kind       = "Namespace"
+    metadata = {
+      name = var.external_dns.namespace
+    }
+  } : null
+
+  external_dns_secret_manifest = var.external_dns.enabled ? {
+    apiVersion = "v1"
+    kind       = "Secret"
+    type       = "Opaque"
+    metadata = {
+      name      = "external-dns-hcloud"
+      namespace = var.external_dns.namespace
+    }
+    data = {
+      api-token = base64encode(var.hcloud_token)
+    }
+  } : null
+
+  external_dns_txt_owner_id = coalesce(var.external_dns.txt_owner_id, var.cluster_name)
+}
+
+data "helm_template" "external_dns" {
+  count = var.external_dns.enabled ? 1 : 0
+
+  name      = "external-dns"
+  namespace = var.external_dns.namespace
+
+  repository   = var.external_dns.helm.repository
+  chart        = var.external_dns.helm.chart
+  version      = var.external_dns.helm.version
+  kube_version = var.kubernetes_version
+
+  values = [
+    yamlencode({
+      provider = {
+        name = "webhook"
+        webhook = {
+          image = {
+            repository = var.external_dns.webhook.image_repository
+            tag        = var.external_dns.webhook.image_tag
+            pullPolicy = "IfNotPresent"
+          }
+          env = [
+            {
+              name = "HETZNER_API_KEY"
+              valueFrom = {
+                secretKeyRef = {
+                  name = "external-dns-hcloud"
+                  key  = "api-token"
+                }
+              }
+            },
+            {
+              name  = "USE_CLOUD_API"
+              value = var.external_dns.webhook.use_cloud_api ? "true" : "false"
+            }
+          ]
+          livenessProbe = {
+            httpGet = {
+              path = "/health"
+              port = "http-webhook"
+            }
+            initialDelaySeconds = 10
+            timeoutSeconds      = 5
+          }
+          readinessProbe = {
+            httpGet = {
+              path = "/ready"
+              port = "http-webhook"
+            }
+            initialDelaySeconds = 10
+            timeoutSeconds      = 5
+          }
+        }
+      }
+      sources       = var.external_dns.sources
+      domainFilters = var.external_dns.domain_filters
+      txtOwnerId    = local.external_dns_txt_owner_id
+      txtPrefix     = var.external_dns.txt_prefix
+      policy        = var.external_dns.policy
+      registry      = var.external_dns.registry
+      interval      = var.external_dns.interval
+      extraArgs = {
+        "webhook-provider-url" = "http://localhost:8888"
+      }
+    }),
+    yamlencode(var.external_dns.helm.values)
+  ]
+}
+
+locals {
+  external_dns_manifest = var.external_dns.enabled ? {
+    name     = "external-dns"
+    contents = <<-EOF
+      ${yamlencode(local.external_dns_namespace)}
+      ---
+      ${yamlencode(local.external_dns_secret_manifest)}
+      ---
+      ${data.helm_template.external_dns[0].manifest}
+    EOF
+  } : null
+}

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -21,6 +21,7 @@ locals {
     local.cert_manager_manifest != null ? [local.cert_manager_manifest] : [],
     local.ingress_nginx_manifest != null ? [local.ingress_nginx_manifest] : [],
     local.cluster_autoscaler_manifest != null ? [local.cluster_autoscaler_manifest] : [],
+    local.external_dns_manifest != null ? [local.external_dns_manifest] : [],
     var.talos_extra_inline_manifests != null ? var.talos_extra_inline_manifests : [],
     local.rbac_manifest != null ? [local.rbac_manifest] : [],
     local.oidc_manifest != null ? [local.oidc_manifest] : []

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,33 +3,34 @@ terraform {
 
   required_providers {
     talos = {
-      source  = "siderolabs/talos"
+      source  = "registry.terraform.io/siderolabs/talos"
       version = "0.9.0"
     }
 
     hcloud = {
-      source  = "hetznercloud/hcloud"
-      version = "1.58.0"
+      source  = "registry.terraform.io/hetznercloud/hcloud"
+      version = "1.59.0"
     }
 
     helm = {
-      source  = "hashicorp/helm"
+      source  = "registry.terraform.io/hashicorp/helm"
       version = "~> 3.1.0"
     }
 
     http = {
-      source  = "hashicorp/http"
+      source  = "registry.terraform.io/hashicorp/http"
       version = "~> 3.5.0"
     }
 
     tls = {
-      source  = "hashicorp/tls"
+      source  = "registry.terraform.io/hashicorp/tls"
       version = "~> 4.1.0"
     }
 
     random = {
-      source  = "hashicorp/random"
+      source  = "registry.terraform.io/hashicorp/random"
       version = "~>3.7.2"
     }
+
   }
 }


### PR DESCRIPTION
**What**
- Manage Hetzner DNS zones/records and wire external-dns into the Talos inline manifests.

**Why**
- External DNS and DNS records should be fully managed via Terraform per `issue-external-dns.md`.

**Changes**
- Add `hcloud_zone` creation gated by new `dns_zone_create`/`dns_zone_name` vars.
- Add external-dns Helm templating + webhook config + secret/namespace manifests.
- Inject external-dns manifest into Talos inline manifests.
- Update provider sources to explicit registry URLs and bump `hcloud` to `1.59.0`.

Closes #306