### PR TITLE
Remove temporary longhorn hotfix for image tag

### DIFF
--- a/longhorn.tf
+++ b/longhorn.tf
@@ -28,14 +28,6 @@ data "helm_template" "longhorn" {
 
   values = [
     yamlencode({
-      # Temporary Hotfix: https://github.com/longhorn/longhorn/issues/12259
-      image = {
-        longhorn = {
-          manager = {
-            tag = "v1.10.1-hotfix-1"
-          }
-        }
-      }
       preUpgradeChecker = {
         upgradeVersionCheck = false
       }


### PR DESCRIPTION
This pull request makes a targeted update to the Longhorn Helm deployment configuration by removing a temporary hotfix image override. This change ensures that the deployment will use the default image tag specified by the Longhorn Helm chart, rather than the previously pinned hotfix version.

Helm template configuration update:

* Removed the custom image tag override (`v1.10.1-hotfix-1`) for the Longhorn manager image, reverting to the default image specified by the chart.