### PR TITLE
chore(deps): update skip release rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,11 +43,14 @@
       "enabled": false
     },
     {
-      "description": "Talos — skip x.y.0 releases",
+      "description": "Skip X.Y.0 releases",
       "matchDatasources": [
-        "github-tags"
+        "github-tags",
+        "helm"
       ],
       "matchDepNames": [
+        "cilium",
+        "longhorn",
         "siderolabs/talos"
       ],
       "allowedVersions": "!/^v?\\d+\\.\\d+\\.0$/"


### PR DESCRIPTION
Going forward, we treat the **first patch release of a new minor version** (**X.Y.1**) as the first “stable” release for **Cilium** and **Longhorn**. As a result, we explicitly **skip X.Y.0** releases for these projects.

* **Clarified rule intent:** Updated the Renovate config description to clearly communicate that **X.Y.0 releases are skipped**.
* **Expanded matching scope:** Extended the rule to also match:

  * the `helm` datasource, and
  * the `cilium` and `longhorn` dependencies
    so that **X.Y.0** releases are skipped consistently across these update sources.

References:
- https://github.com/longhorn/longhorn/wiki/Release-Schedule-&-Support
- https://docs.cilium.io/en/stable/contributing/release/organization/

