### PR TITLE
feat: migrate Talos disk configuration to VolumeConfig documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,20 @@ Here is a table with more example calculations:
  
 </details>
 
+<!-- Node Reboots on Configuration Changes -->
+<details>
+<summary><b>Node Reboots on Configuration Changes</b></summary>
+Most configuration changes to Talos can be applied seamlessly without disruption. However, certain low-level modifications strictly require a reboot.
+
+By default, the module automatically calculates whether a configuration change requires a reboot and safely reboots the affected nodes one by one to ensure a zero-downtime application of your machine config.
+
+If you prefer to manage the rebooting of the nodes manually after configuration updates (for example, scheduling them in a specific maintenance window), you can disable automatic reboots with the following variable:
+
+```hcl
+talos_staged_configuration_automatic_reboot_enabled = false
+```
+
+</details>
 
 <!-- Storage Configuration-->
 <details>

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -9,6 +9,12 @@ locals {
     "oidc-groups-prefix"  = var.oidc_groups_prefix
   } : {}
 
+  # Talos configuration documents
+  talos_configuration_manifests = compact([
+    # VolumeConfig documents - system disk encryption
+    local.talos_manifest_volumeconfigs
+  ])
+
   # Kubernetes Manifests for Talos
   talos_inline_manifests = concat(
     [local.hcloud_secret_manifest],
@@ -95,30 +101,6 @@ locals {
       }
     ] : [],
     var.talos_extra_host_entries
-  )
-
-  # Disk Encryption Configuration
-  talos_system_disk_encryption = merge(
-    var.talos_state_partition_encryption_enabled ? {
-      state = {
-        provider = "luks2"
-        options  = ["no_read_workqueue", "no_write_workqueue"]
-        keys = [{
-          nodeID = {}
-          slot   = 0
-        }]
-      }
-    } : {},
-    var.talos_ephemeral_partition_encryption_enabled ? {
-      ephemeral = {
-        provider = "luks2"
-        options  = ["no_read_workqueue", "no_write_workqueue"]
-        keys = [{
-          nodeID = {}
-          slot   = 0
-        }]
-      }
-    } : {}
   )
 
   # Kubelet extra mounts
@@ -250,8 +232,7 @@ locals {
           },
           var.talos_sysctls_extra_args
         )
-        registries           = var.talos_registries
-        systemDiskEncryption = local.talos_system_disk_encryption
+        registries = var.talos_registries
         features = {
           kubernetesTalosAPIAccess = {
             enabled = true,
@@ -430,8 +411,7 @@ locals {
           },
           var.talos_sysctls_extra_args
         )
-        registries           = var.talos_registries
-        systemDiskEncryption = local.talos_system_disk_encryption
+        registries = var.talos_registries
         features = {
           hostDNS = local.talos_host_dns
         }
@@ -540,8 +520,7 @@ locals {
           },
           var.talos_sysctls_extra_args
         )
-        registries           = var.talos_registries
-        systemDiskEncryption = local.talos_system_disk_encryption
+        registries = var.talos_registries
         features = {
           hostDNS = local.talos_host_dns
         }
@@ -586,8 +565,12 @@ data "talos_machine_configuration" "control_plane" {
   examples           = false
 
   config_patches = concat(
+    # Main v1alpha1 machine configuration
     [yamlencode(local.control_plane_talos_config_patch[each.key])],
-    [for patch in var.control_plane_config_patches : yamlencode(patch)]
+    # User-provided configuration patches
+    [for patch in var.control_plane_config_patches : yamlencode(patch)],
+    # Common talos configuration manifests
+    local.talos_configuration_manifests
   )
 }
 
@@ -604,8 +587,12 @@ data "talos_machine_configuration" "worker" {
   examples           = false
 
   config_patches = concat(
+    # Main v1alpha1 machine configuration
     [yamlencode(local.worker_talos_config_patch[each.key])],
-    [for patch in var.worker_config_patches : yamlencode(patch)]
+    # User-provided configuration patches
+    [for patch in var.worker_config_patches : yamlencode(patch)],
+    # Common talos configuration manifests
+    local.talos_configuration_manifests
   )
 }
 
@@ -622,7 +609,11 @@ data "talos_machine_configuration" "cluster_autoscaler" {
   examples           = false
 
   config_patches = concat(
+    # Main v1alpha1 machine configuration
     [yamlencode(local.autoscaler_nodepool_talos_config_patch[each.key])],
-    [for patch in var.cluster_autoscaler_config_patches : yamlencode(patch)]
+    # User-provided configuration patches
+    [for patch in var.cluster_autoscaler_config_patches : yamlencode(patch)],
+    # Common talos configuration manifests
+    local.talos_configuration_manifests
   )
 }

--- a/talos_manifest.tf
+++ b/talos_manifest.tf
@@ -1,0 +1,30 @@
+locals {
+  # VolumeConfig documents
+  talos_manifest_volumeconfigs = trimspace(join(
+    "\n---\n",
+    compact([
+      # STATE partition (/system/state)
+      var.talos_state_partition_encryption_enabled ? yamlencode({
+        apiVersion = "v1alpha1"
+        kind       = "VolumeConfig"
+        name       = "STATE"
+        encryption = {
+          provider = "luks2"
+          options  = ["no_read_workqueue", "no_write_workqueue"]
+          keys     = [{ nodeID = {}, slot = 0 }]
+        }
+      }) : null,
+      # EPHEMERAL partition (/var)
+      var.talos_ephemeral_partition_encryption_enabled ? yamlencode({
+        apiVersion = "v1alpha1"
+        kind       = "VolumeConfig"
+        name       = "EPHEMERAL"
+        encryption = {
+          provider = "luks2"
+          options  = ["no_read_workqueue", "no_write_workqueue"]
+          keys     = [{ nodeID = {}, slot = 0 }]
+        }
+      }) : null,
+    ])
+  ))
+}


### PR DESCRIPTION
Hi @M4t7e!

Hope everything is going well. 😄

This PR migrates the Talos disk encryption configuration to dedicated `v1alpha1` `VolumeConfig` documents, targeting Talos v1.11+.

Regards!