### PR TITLE
Revert "chore(deps): update helm release cilium to v1.19.1"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1432,7 +1432,7 @@ variable "cilium_helm_chart" {
 
 variable "cilium_helm_version" {
   type        = string
-  default     = "1.19.1"
+  default     = "1.18.7"
   description = "Version of the Cilium Helm chart to deploy."
 }
 


### PR DESCRIPTION
Reverts hcloud-k8s/terraform-hcloud-kubernetes#322

There is an issue when upgrading to Cilium 1.19. The Cilium DaemonSet containers hang during initialization and remain stuck. The only way to recover is to fully reboot all cluster nodes.

This is probably the issue: https://github.com/cilium/cilium/issues/44216

We'll stay on Cilium 1.18 until the issue is fully resolved.