### PR TITLE
chore(renovate): skip cert-manager X.Y.0 releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,6 +49,7 @@
         "helm"
       ],
       "matchDepNames": [
+        "cert-manager",
         "cilium",
         "longhorn",
         "siderolabs/talos"


### PR DESCRIPTION
Skip initial `X.Y.0` releases as a safeguard. Cert Manager maintains two minor versions in parallel, so waiting for `X.Y.1` reduces upgrade risk while staying on a supported release line.

Reference: https://cert-manager.io/docs/releases/