### PR TITLE
Revert "chore(deps): update dependency kubernetes-sigs/gateway-api to v1.5.0"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1959,7 +1959,7 @@ variable "gateway_api_crds_enabled" {
 
 variable "gateway_api_crds_version" {
   type        = string
-  default     = "v1.5.0" # https://github.com/kubernetes-sigs/gateway-api
+  default     = "v1.4.1" # https://github.com/kubernetes-sigs/gateway-api
   description = "Specifies the version of the Gateway API Custom Resource Definitions (CRDs) to deploy."
 }
 


### PR DESCRIPTION
Reverts hcloud-k8s/terraform-hcloud-kubernetes#345

Revert to Gateway API 1.4.1 due to a potential issue in Cillium:
```
time=2026-03-07T10:39:08.8744835Z level=error msg="Invoke failed" error="failed to create gateway controller: failed to setup reconciler: failed to setup field indexer \"backendServiceTLSRouteIndex\": no matches for kind \"TLSRoute\" in version \"gateway.networking.k8s.io/v1alpha2\"" function="gateway-api.initGatewayAPIController (pkg/gateway-api/cell.go:108)"
time=2026-03-07T10:39:08.874574098Z level=info msg="Stopping hive"
time=2026-03-07T10:39:08.874590319Z level=info msg="Stopped hive" duration=6.303µs
time=2026-03-07T10:39:08.874612752Z level=fatal msg="failed to start: failed to populate object graph: failed to create gateway controller: failed to setup reconciler: failed to setup field indexer \"backendServiceTLSRouteIndex\": no matches for kind \"TLSRoute\" in version \"gateway.networking.k8s.io/v1alpha2\""
```

⚠️ If you have **already upgraded to `3.26.0`**, follow these instructions to resolve the issue:

1. Remove all Gateway API resources from the cluster so that the related CRDs can be deleted.

2. Delete the Gateway API CRDs:

   ```bash
   kubectl delete crd backendtlspolicies.gateway.networking.k8s.io
   kubectl delete crd gatewayclasses.gateway.networking.k8s.io
   kubectl delete crd gateways.gateway.networking.k8s.io
   kubectl delete crd grpcroutes.gateway.networking.k8s.io
   kubectl delete crd httproutes.gateway.networking.k8s.io
   kubectl delete crd listenersets.gateway.networking.k8s.io
   kubectl delete crd referencegrants.gateway.networking.k8s.io
   kubectl delete crd tlsroutes.gateway.networking.k8s.io
   ```

3. Delete the Gateway API upgrade safeguards:

   ```bash
   kubectl delete validatingadmissionpolicybinding safe-upgrades.gateway.networking.k8s.io
   kubectl delete validatingadmissionpolicy safe-upgrades.gateway.networking.k8s.io
   ```

4. Upgrade to the next highest hcloud Kubernetes version available for your cluster.

    **If the upgrade fails, repeat the procedure from step 3 onward until the upgrade succeeds.**
