### PR TITLE
fix: prevent health check data sources from blocking plan and destroy (#367)

### DIFF
--- a/talos.tf
+++ b/talos.tf
@@ -75,6 +75,12 @@ locals {
     )
   })
 
+  # Health Check
+  cluster_health_check_commands = templatefile("${path.module}/templates/cluster_health_check.sh.tftpl", {
+    kube_api_url   = local.kube_api_url_external
+    cluster_access = var.cluster_access
+  })
+
   # Cluster Status
   cluster_initialized = length(data.hcloud_certificates.state.certificates) > 0
 }
@@ -406,36 +412,28 @@ resource "terraform_data" "talos_access_data" {
   }
 }
 
-data "http" "kube_api_health" {
+resource "terraform_data" "cluster_health_check" {
   count = var.cluster_healthcheck_enabled ? 1 : 0
 
-  url      = "${terraform_data.talos_access_data.output.kube_api_url}/version"
-  insecure = true
+  triggers_replace = [
+    terraform_data.synchronize_manifests.id
+  ]
 
-  retry {
-    attempts     = 60
-    min_delay_ms = 5000
-    max_delay_ms = 5000
-  }
+  provisioner "local-exec" {
+    when  = create
+    quiet = true
+    command = join("\n",
+      [
+        "set -eu",
+        local.talosctl_commands,
+        local.cluster_health_check_commands,
+      ]
+    )
 
-  lifecycle {
-    postcondition {
-      condition     = self.status_code == 401
-      error_message = "Status code invalid"
+    environment = {
+      TALOSCONFIG = nonsensitive(data.talos_client_configuration.this.talos_config)
     }
   }
 
   depends_on = [terraform_data.synchronize_manifests]
-}
-
-data "talos_cluster_health" "this" {
-  count = var.cluster_healthcheck_enabled && (var.cluster_access == "private") ? 1 : 0
-
-  client_configuration   = talos_machine_secrets.this.client_configuration
-  endpoints              = terraform_data.talos_access_data.output.endpoints
-  control_plane_nodes    = terraform_data.talos_access_data.output.control_plane_nodes
-  worker_nodes           = terraform_data.talos_access_data.output.worker_nodes
-  skip_kubernetes_checks = false
-
-  depends_on = [data.http.kube_api_health]
 }

--- a/templates/cluster_health_check.sh.tftpl
+++ b/templates/cluster_health_check.sh.tftpl
@@ -1,0 +1,20 @@
+printf '%s\n' "Waiting for Kube API to be reachable..."
+api_retry=1
+while [ $api_retry -le 60 ]; do
+  status=$(curl --insecure --silent --output /dev/null --write-out "%%{http_code}" "${kube_api_url}/version" || echo "000")
+  if [ "$status" = "401" ] || [ "$status" = "200" ]; then
+    printf '%s\n' "Kube API is reachable."
+    break
+  fi
+  printf '%s\n' "API not ready (status $status). Retry $api_retry/60..."
+  api_retry=$((api_retry + 1))
+  sleep 5
+done
+if [ $api_retry -gt 60 ]; then
+  printf '%s\n' "Error: Kube API health check timed out."
+  exit 1
+fi
+%{ if cluster_access == "private" }
+printf '%s\n' "Waiting for Talos cluster health..."
+talos_wait_for_health
+%{ endif }


### PR DESCRIPTION
  Fixes #367

  Currently, `kube_api_health` and `talos_cluster_health` are implemented as `data` sources. Because data sources are evaluated during the refresh phase, an unreachable or unhealthy cluster completely blocks `terraform plan` and `terraform destroy` with a hard timeout error. This leads to a deadlock where users cannot
   apply fixes or tear down broken clusters without manually removing state or temporarily disabling the health check variable.

  ## Solution

  This PR replaces the two `data` sources with a single `terraform_data` resource utilizing a `local-exec` provisioner:

  - **No Refresh Blocking:** Because it is a resource provisioner rather than a data source, it executes during the `apply` phase. This completely unblocks `terraform plan` and `terraform destroy`.
  - **Maintains Strict Guarantees:** The provisioner uses `on_failure = fail` (default). If the cluster is still unhealthy at the end of an `apply`, Terraform will hard-error, preserving the strict validation contract of `cluster_healthcheck_enabled = true`.
  - **Clean Separation:** The bash retry logic (which replaces the old `http` data source) has been placed in a new `templates/cluster_health_check.sh.tftpl` file, keeping the HCL clean and matching the repository's existing `talosctl_commands` pattern.
  - **State Migration is Automatic:** Existing users updating to this version will automatically drop the old `data` sources from their state and track the new `terraform_data` resource on their next apply without any manual intervention.

  ## Why not `check` blocks?

  `check` blocks (Terraform 1.5+) were considered but rejected:

  - **No `count` support:** `check` blocks don't support `count` or `for_each`, so `cluster_healthcheck_enabled = false` cannot fully disable them. The scoped data source inside still executes — and if it fails (unreachable cluster), Terraform emits a warning regardless of the variable setting.
  - **Weaker guarantees:** `check` blocks only emit warnings, never errors. This would silently downgrade the `cluster_healthcheck_enabled = true` contract from a hard failure to a soft warning on unhealthy clusters.
  - **No `depends_on` on the block itself:** Ordering relative to `synchronize_manifests` would rely on implicit dependencies only.

  The `terraform_data` approach avoids all three issues while following the existing patterns in the codebase.