### PR TITLE
fix: (v4) 0.0.0.0/0 route handling

### DIFF
--- a/talos_config_base.tf
+++ b/talos_config_base.tf
@@ -31,11 +31,15 @@ locals {
   talos_private_link_name        = local.talos_public_interface_enabled ? "eth1" : "eth0"
 
   # Routes
-  talos_extra_routes = [for cidr in var.talos_extra_routes : {
-    destination = cidr
-    gateway     = local.network_ipv4_gateway
-    metric      = 512
-  }]
+  # Note: Default route (0.0.0.0/0) omits the 'network' key per Talos routing config requirements
+  # See https://github.com/siderolabs/talos/issues/12521
+  talos_extra_routes = [for cidr in var.talos_extra_routes : merge(
+    {
+      gateway = local.network_ipv4_gateway
+      metric  = 512
+    },
+    cidr != "0.0.0.0/0" ? { destination = cidr } : {}
+  )]
 
   # DNS Configuration
   talos_host_dns = {


### PR DESCRIPTION
Hi @M4t7e!

I did some tests with the master branch and got the following error on apply.

```bash
 Error: Error applying configuration
  │ 
  │   with module.kubernetes.talos_machine_configuration_apply.control_plane["eb-hcloud-pre-cplane-nbg1-1"],
  │   on ../../../../../../../terraform-hcloud-kubernetes/talos.tf line 247, in resource "talos_machine_configuration_apply" "control_plane":
  │  247: resource "talos_machine_configuration_apply" "control_plane" {
  │ 
  │ rpc error: code = InvalidArgument desc = 1 error occurred:
  │     * LinkConfig/eth0: route 0 destination must be a valid IP prefix
```
My clusters only have private networking, so adding 0.0.0.0/0 as an extra route is necessary to route everything through the subnet GW.

This error is due https://github.com/siderolabs/talos/issues/12521
LinkConfig routes forbids setting 0.0.0.0/0 as a destination, seems to be implicit if you set the GW only.

This PR fixes 0.0.0.0/0 route handling keeping backwards compatibility.

Regards!