### PR TITLE
fix(ssh_key): trim trailing newline from tls public_key_openssh

### DIFF
--- a/ssh_key.tf
+++ b/ssh_key.tf
@@ -4,7 +4,7 @@ resource "tls_private_key" "ssh_key" {
 
 resource "hcloud_ssh_key" "this" {
   name       = "${var.cluster_name}-default"
-  public_key = tls_private_key.ssh_key.public_key_openssh
+  public_key = trimspace(tls_private_key.ssh_key.public_key_openssh)
 
   labels = {
     cluster = var.cluster_name


### PR DESCRIPTION
## Summary

Fixes `Error: Provider produced inconsistent result after apply` on `hcloud_ssh_key.this` when the module is used to bootstrap a cluster from scratch.

## Root cause

`tls_private_key.ssh_key.public_key_openssh` returns the OpenSSH-encoded key with a trailing `\n` (this is the OpenSSH convention and is baked into the `hashicorp/tls` provider).

The Hetzner Cloud API strips trailing whitespace when persisting an SSH key. As a result, the value the `hetznercloud/hcloud` provider returns after `apply` does not equal the value Terraform planned, and Terraform raises the "inconsistent result after apply" error:

```
Error: Provider produced inconsistent result after apply

When applying changes to module.<env>.hcloud_ssh_key.this, provider
"hetznercloud/hcloud" produced an unexpected new value:
.public_key: was cty.StringVal("ssh-ed25519 AAAA...\n"),
             but now cty.StringVal("ssh-ed25519 AAAA...").
```

The SSH key is actually created successfully in Hetzner; only the state reconciliation fails, which leaves the resource orphaned (exists in Hetzner, missing from state) and blocks every subsequent `apply`.

## Fix

Wrap the input with `trimspace(...)` in `ssh_key.tf`:

```diff
 resource "hcloud_ssh_key" "this" {
   name       = "${var.cluster_name}-default"
-  public_key = tls_private_key.ssh_key.public_key_openssh
+  public_key = trimspace(tls_private_key.ssh_key.public_key_openssh)
   ...
 }
```