### PR TITLE
feat(talos): set staged_if_needing_reboot as default apply mode

### DIFF
--- a/talos.tf
+++ b/talos.tf
@@ -254,12 +254,6 @@ resource "talos_machine_configuration_apply" "control_plane" {
 
   apply_mode = var.talos_machine_configuration_apply_mode
 
-  on_destroy = {
-    graceful = var.cluster_graceful_destroy
-    reset    = true
-    reboot   = false
-  }
-
   depends_on = [
     hcloud_load_balancer_service.kube_api,
     terraform_data.upgrade_kubernetes
@@ -311,12 +305,6 @@ resource "talos_machine_configuration_apply" "worker" {
   endpoint                    = var.cluster_access == "private" ? tolist(each.value.network)[0].ip : coalesce(each.value.ipv4_address, each.value.ipv6_address)
   node                        = tolist(each.value.network)[0].ip
   apply_mode                  = var.talos_machine_configuration_apply_mode
-
-  on_destroy = {
-    graceful = var.cluster_graceful_destroy
-    reset    = true
-    reboot   = false
-  }
 
   depends_on = [
     terraform_data.upgrade_kubernetes,

--- a/variables.tf
+++ b/variables.tf
@@ -76,12 +76,6 @@ variable "cluster_talosconfig_path" {
   description = "If not null, the talosconfig will be written to a file speficified."
 }
 
-variable "cluster_graceful_destroy" {
-  type        = bool
-  default     = true
-  description = "Determines whether a graceful destruction process is enabled for Talos nodes. When enabled, it ensures that nodes are properly drained and decommissioned before being destroyed, minimizing disruption in the cluster."
-}
-
 variable "cluster_healthcheck_enabled" {
   type        = bool
   default     = true
@@ -684,7 +678,7 @@ variable "talos_kernel_modules" {
 
 variable "talos_machine_configuration_apply_mode" {
   type        = string
-  default     = "auto"
+  default     = "staged_if_needing_reboot"
   description = "Determines how changes to Talos machine configurations are applied. 'auto' (default) applies changes immediately and reboots if necessary. 'reboot' applies changes and then reboots the node. 'no_reboot' applies changes immediately without a reboot, failing if a reboot is required. 'staged' stages changes to apply on the next reboot. 'staged_if_needing_reboot' performs a dry-run and uses 'staged' mode if reboot is needed, 'auto' otherwise."
 
   validation {


### PR DESCRIPTION
* Removed the on_destroy block from control plane and worker resources due to a bug terraform provider: https://github.com/siderolabs/terraform-provider-talos/issues/334
* Updated default value of talos_machine_configuration_apply_mode to 'staged_if_needing_reboot'