### PR TITLE
feat(cluster-autoscaler): enable discovery by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -519,7 +519,7 @@ variable "cluster_autoscaler_config_patches" {
 
 variable "cluster_autoscaler_discovery_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Enable rolling upgrades of Cluster Autoscaler nodes during Talos OS upgrades and Talos configuration changes."
 }
 


### PR DESCRIPTION
* Set cluster_autoscaler_discovery_enabled to true
* Allows rolling upgrades of Cluster Autoscaler nodes during Talos OS upgrades