### PR TITLE
feat: pre-provision private network manifests via user_data

### DIFF
--- a/server.tf
+++ b/server.tf
@@ -26,6 +26,7 @@ resource "hcloud_server" "control_plane" {
   keep_disk                = each.value.keep_disk
   ssh_keys                 = [hcloud_ssh_key.this.id]
   shutdown_before_deletion = true
+  user_data                = local.talos_user_data
   delete_protection        = var.cluster_delete_protection
   rebuild_protection       = var.cluster_delete_protection
 
@@ -90,6 +91,7 @@ resource "hcloud_server" "worker" {
   keep_disk                = each.value.keep_disk
   ssh_keys                 = [hcloud_ssh_key.this.id]
   shutdown_before_deletion = true
+  user_data                = local.talos_user_data
   delete_protection        = var.cluster_delete_protection
   rebuild_protection       = var.cluster_delete_protection
 

--- a/talos_config_base.tf
+++ b/talos_config_base.tf
@@ -206,6 +206,15 @@ locals {
     }
   ] : []
 
+  # Boot-time machine configuration
+  talos_user_data_config_patches = concat(
+    [for p in concat(local.talos_private_link_config_patches, local.talos_private_dhcp_config_patches) : p if var.cluster_access == "private"],
+  )
+
+  talos_user_data = length(local.talos_user_data_config_patches) > 0 ? join("\n---\n", [
+    for patch in local.talos_user_data_config_patches : yamlencode(patch)
+  ]) : null
+
   # Talos Base Config
   talos_base_config_patches = concat(
     [{


### PR DESCRIPTION
Hi @M4t7e
Hope everything is going well :grin: 

## Summary
* Closes #397

This PR injects minimal Talos LinkConfig and DHCPv4Config documents via user_data so that private interface routing is established at boot time, before the Talos API needs to be reachable.

When cluster_access = "private", nodes boot without default routes beyond their VPC subnet. This creates a chicken-and-egg problem for non-SNAT VPN setups (e.g., Headscale, WireGuard without masquerade) as talos_machine_configuration_apply can't reach the node because the full network configuration (including extra routes) hasn't been applied yet.

