### PR TITLE
feat(cluster-autoscaler): clean up orphaned Hetzner servers on destroy

### DIFF
--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -1,6 +1,7 @@
 locals {
-  cluster_autoscaler_enabled          = length(local.cluster_autoscaler_nodepools) > 0
-  cluster_autoscaler_hostname_pattern = "^${var.cluster_name}-(${join("|", distinct([for np in local.cluster_autoscaler_nodepools : np.name]))})-[0-9a-f]+$"
+  cluster_autoscaler_enabled             = length(local.cluster_autoscaler_nodepools) > 0
+  cluster_autoscaler_hostname_pattern    = "^${var.cluster_name}-(${join("|", distinct([for np in local.cluster_autoscaler_nodepools : np.name]))})-[0-9a-f]+$"
+  cluster_autoscaler_node_label_selector = local.cluster_autoscaler_enabled ? "hcloud/node-group in (${join(",", [for np in local.cluster_autoscaler_nodepools : "${var.cluster_name}-${np.name}"])})" : ""
 
   cluster_autoscaler_release_name       = "cluster-autoscaler"
   cluster_autoscaler_cloud_provider     = "hetzner"

--- a/server.tf
+++ b/server.tf
@@ -52,6 +52,7 @@ resource "hcloud_server" "control_plane" {
   }
 
   depends_on = [
+    terraform_data.hcloud_server_cluster_autoscaler,
     hcloud_network_subnet.control_plane,
     hcloud_placement_group.control_plane
   ]
@@ -117,6 +118,7 @@ resource "hcloud_server" "worker" {
   }
 
   depends_on = [
+    terraform_data.hcloud_server_cluster_autoscaler,
     hcloud_network_subnet.worker,
     hcloud_placement_group.worker
   ]
@@ -127,6 +129,74 @@ resource "hcloud_server" "worker" {
       user_data,
       ssh_keys
     ]
+  }
+}
+
+resource "terraform_data" "hcloud_server_cluster_autoscaler" {
+  triggers_replace = {
+    hcloud_api_token = var.hcloud_token
+  }
+
+  input = {
+    hcloud_api_url      = "https://api.hetzner.cloud/v1"
+    cleanup_enabled     = var.cluster_autoscaler_cleanup_enabled
+    node_label_selector = local.cluster_autoscaler_node_label_selector
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    quiet   = true
+    command = <<-EOT
+      set -eu
+
+      if [ "${self.input.cleanup_enabled}" != "true" ] || [ -z "${self.input.node_label_selector}" ]; then
+        exit 0
+      fi
+
+      tab=$(printf '\011')
+
+      hcloud_api() {
+        curl -sSf \
+          -H "Authorization: Bearer $HCLOUD_TOKEN" \
+          --connect-timeout 10 \
+          --retry 5 \
+          --retry-all-errors \
+          --retry-delay 10 \
+          "$@"
+      }
+
+      nodes=$(
+        page=1
+        while :; do
+          response=$(
+            hcloud_api \
+              --get "${self.output.hcloud_api_url}/servers" \
+              --data-urlencode "per_page=50" \
+              --data-urlencode "page=$page" \
+              --data-urlencode "label_selector=${self.output.node_label_selector}"
+          )
+          printf '%s\n' "$response" | jq -c '.servers[] | {id,name}'
+
+          next_page=$(printf '%s\n' "$response" | jq -r '.meta.pagination.next_page')
+          if [ "$next_page" = "null" ]; then
+            break
+          fi
+
+          page=$next_page
+        done | jq -rs 'unique_by(.id)[] | "\(.id)\t\(.name)"'
+      )
+
+      if [ -n "$nodes" ]; then
+        printf '%s\n' "$nodes" | while IFS="$tab" read -r id name; do
+          printf 'Deleting %s (%s)\n' "$name" "$id"
+          hcloud_api -X DELETE "${self.output.hcloud_api_url}/servers/$id" >/dev/null
+        done
+      fi
+    EOT
+
+    environment = {
+      HCLOUD_TOKEN = nonsensitive(self.triggers_replace.hcloud_api_token)
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -523,6 +523,12 @@ variable "cluster_autoscaler_discovery_enabled" {
   description = "Enable rolling upgrades of Cluster Autoscaler nodes during Talos OS upgrades and Talos configuration changes."
 }
 
+variable "cluster_autoscaler_cleanup_enabled" {
+  type        = bool
+  default     = false
+  description = "Enables cleanup of Hetzner Cloud servers created by Cluster Autoscaler during Terraform destroy. When enabled, matching autoscaler nodes are deleted before managed cluster resources are removed. Warning: disable this option before changing hcloud_token; otherwise Terraform may delete all Cluster Autoscaler nodes."
+}
+
 
 # Packer
 variable "packer_amd64_builder" {


### PR DESCRIPTION
Add optional destroy-time cleanup for Hetzner Cloud servers created by Cluster Autoscaler. The cleanup runs after managed control plane and worker nodes are destroyed so the autoscaler cannot recreate deleted nodes, and skips execution when cleanup is disabled or no autoscaler node selector is available.

Closes #278