### PR TITLE
feat(cert-manager): add Hetzner DNS webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,9 +585,17 @@ cert_manager_enabled                 = true
 cert_manager_webhook_hetzner_enabled = true
 ```
 
-The module creates a `hetzner` Secret in the `cert-manager` namespace using `hcloud_token` by default. To use a separate DNS token, set `cert_manager_webhook_hetzner_token`.
+Your DNS zone must be managed by Hetzner DNS. Create a Secret containing a Hetzner API token with permission to create and remove DNS records. For `ClusterIssuer` resources, place the Secret in the cert-manager cluster resource namespace, which defaults to `cert-manager`.
 
-Your DNS zone must be managed by Hetzner DNS, and the token must have permission to create and remove DNS records.
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hetzner
+  namespace: cert-manager
+stringData:
+  token: <hetzner-dns-token>
+```
 
 ```yaml
 apiVersion: cert-manager.io/v1

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ This project bundles essential Kubernetes components, preconfigured for seamless
   </summary>
   Automates the management of certificates in Kubernetes, handling the issuance and renewal of certificates from various sources like Let's Encrypt, and ensures certificates are valid and updated.
 - <summary>
+    <img align="center" alt="Easy" src="https://www.google.com/s2/favicons?domain=hetzner.com&sz=32" width="16">
+    <b><a href="https://github.com/hetzner/cert-manager-webhook-hetzner">Cert Manager Webhook Hetzner</a></b>
+  </summary>
+  Adds Hetzner DNS support for Cert Manager ACME DNS-01 challenges, including wildcard certificates and certificates that do not depend on public HTTP routing.
+- <summary>
     <img align="center" alt="Easy" src="https://www.google.com/s2/favicons?domain=kubernetes.io&sz=32" width="16">
     <b><a href="https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler">Cluster Autoscaler</a></b>
   </summary>
@@ -571,6 +576,43 @@ spec:
                 kind: Gateway
 ```
 
+#### Optional: Create a Cert Manager `ClusterIssuer` (Let's Encrypt DNS-01 via Hetzner DNS)
+
+To request wildcard certificates or certificates that do not depend on public HTTP routing, enable the Hetzner DNS webhook:
+
+```hcl
+cert_manager_enabled                 = true
+cert_manager_webhook_hetzner_enabled = true
+```
+
+The module creates a `hetzner` Secret in the `cert-manager` namespace using `hcloud_token` by default. To use a separate DNS token, set `cert_manager_webhook_hetzner_token`.
+
+Your DNS zone must be managed by Hetzner DNS, and the token must have permission to create and remove DNS records.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-dns01
+spec:
+  acme:
+    email: <user@example.com>
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-dns01-key
+    solvers:
+      - dns01:
+          webhook:
+            groupName: acme.hetzner.com
+            solverName: hetzner
+            config:
+              tokenSecretKeyRef:
+                name: hetzner
+                key: token
+```
+
+When using this `ClusterIssuer` with the Gateway shim, replace `cert-manager.io/issuer: letsencrypt-http01` with `cert-manager.io/cluster-issuer: letsencrypt-dns01`.
+
 #### Create the `Gateway` (Cilium GatewayClass + Hetzner LB + Cert Manager integration)
 
 A `Gateway` defines the external entry point for traffic. With `gatewayClassName: cilium`, the resource is reconciled by the Cilium Gateway controller. The `infrastructure.annotations` are passed through as Hetzner-specific load balancer settings (interpreted by the Hetzner Cloud Controller Manager) to control how the Hetzner Cloud LB is created and configured. See: [Load Balancer Annotations](https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/main/docs/reference/load_balancer_annotations.md)
@@ -910,9 +952,10 @@ metrics_server_enabled             = true
 prometheus_operator_crds_enabled   = true
 
 # Additional Components (disabled by default)
-cert_manager_enabled               = true
-ingress_nginx_enabled              = true
-longhorn_enabled                   = true
+cert_manager_enabled                 = true
+cert_manager_webhook_hetzner_enabled = true
+ingress_nginx_enabled                = true
+longhorn_enabled                     = true
 
 # Enable etcd backup by defining one of these variables:
 talos_backup_s3_endpoint    = "https://..."
@@ -1278,6 +1321,7 @@ Changing software versions manually is not recommended. Component versions are s
 - Cilium: https://github.com/cilium/cilium/blob/v1.19.2/Documentation/network/kubernetes/compatibility.rst
 - Ingress Nginx: https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table 
 - Cert Manager: https://cert-manager.io/docs/releases/
+- Cert Manager Webhook Hetzner: https://github.com/hetzner/cert-manager-webhook-hetzner/releases
 - Autoscaler: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/README.md#releases
 -->
 

--- a/cert_manager_webhook_hetzner.tf
+++ b/cert_manager_webhook_hetzner.tf
@@ -1,0 +1,66 @@
+locals {
+  cert_manager_webhook_hetzner_token = coalesce(var.cert_manager_webhook_hetzner_token, var.hcloud_token)
+
+  cert_manager_webhook_hetzner_secret_manifest = var.cert_manager_webhook_hetzner_enabled ? {
+    apiVersion = "v1"
+    kind       = "Secret"
+    type       = "Opaque"
+    metadata = {
+      name      = var.cert_manager_webhook_hetzner_secret_name
+      namespace = data.helm_template.cert_manager_webhook_hetzner[0].namespace
+    }
+    data = {
+      (var.cert_manager_webhook_hetzner_secret_key) = base64encode(local.cert_manager_webhook_hetzner_token)
+    }
+  } : null
+
+  cert_manager_webhook_hetzner_values = {
+    groupName    = var.cert_manager_webhook_hetzner_group_name
+    replicaCount = local.control_plane_sum > 1 ? 2 : 1
+    certManager = {
+      namespace          = "cert-manager"
+      serviceAccountName = "cert-manager"
+    }
+    podDisruptionBudget = {
+      enabled        = true
+      minAvailable   = null
+      maxUnavailable = 1
+    }
+    nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
+    tolerations = [
+      {
+        key      = "node-role.kubernetes.io/control-plane"
+        effect   = "NoSchedule"
+        operator = "Exists"
+      }
+    ]
+  }
+}
+
+data "helm_template" "cert_manager_webhook_hetzner" {
+  count = var.cert_manager_webhook_hetzner_enabled ? 1 : 0
+
+  name      = "cert-manager-webhook-hetzner"
+  namespace = "cert-manager"
+
+  repository   = var.cert_manager_webhook_hetzner_helm_repository
+  chart        = var.cert_manager_webhook_hetzner_helm_chart
+  version      = var.cert_manager_webhook_hetzner_helm_version
+  kube_version = var.kubernetes_version
+
+  values = [
+    yamlencode(local.cert_manager_webhook_hetzner_values),
+    yamlencode(var.cert_manager_webhook_hetzner_helm_values)
+  ]
+}
+
+locals {
+  cert_manager_webhook_hetzner_manifest = var.cert_manager_webhook_hetzner_enabled ? {
+    name     = "cert-manager-webhook-hetzner"
+    contents = <<-EOF
+      ${yamlencode(local.cert_manager_webhook_hetzner_secret_manifest)}
+      ---
+      ${data.helm_template.cert_manager_webhook_hetzner[0].manifest}
+    EOF
+  } : null
+}

--- a/cert_manager_webhook_hetzner.tf
+++ b/cert_manager_webhook_hetzner.tf
@@ -1,42 +1,3 @@
-locals {
-  cert_manager_webhook_hetzner_token = coalesce(var.cert_manager_webhook_hetzner_token, var.hcloud_token)
-
-  cert_manager_webhook_hetzner_secret_manifest = var.cert_manager_webhook_hetzner_enabled ? {
-    apiVersion = "v1"
-    kind       = "Secret"
-    type       = "Opaque"
-    metadata = {
-      name      = var.cert_manager_webhook_hetzner_secret_name
-      namespace = data.helm_template.cert_manager_webhook_hetzner[0].namespace
-    }
-    data = {
-      (var.cert_manager_webhook_hetzner_secret_key) = base64encode(local.cert_manager_webhook_hetzner_token)
-    }
-  } : null
-
-  cert_manager_webhook_hetzner_values = {
-    groupName    = var.cert_manager_webhook_hetzner_group_name
-    replicaCount = local.control_plane_sum > 1 ? 2 : 1
-    certManager = {
-      namespace          = "cert-manager"
-      serviceAccountName = "cert-manager"
-    }
-    podDisruptionBudget = {
-      enabled        = true
-      minAvailable   = null
-      maxUnavailable = 1
-    }
-    nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
-    tolerations = [
-      {
-        key      = "node-role.kubernetes.io/control-plane"
-        effect   = "NoSchedule"
-        operator = "Exists"
-      }
-    ]
-  }
-}
-
 data "helm_template" "cert_manager_webhook_hetzner" {
   count = var.cert_manager_webhook_hetzner_enabled ? 1 : 0
 
@@ -49,7 +10,22 @@ data "helm_template" "cert_manager_webhook_hetzner" {
   kube_version = var.kubernetes_version
 
   values = [
-    yamlencode(local.cert_manager_webhook_hetzner_values),
+    yamlencode({
+      groupName    = var.cert_manager_webhook_hetzner_group_name
+      replicaCount = local.control_plane_sum > 1 ? 2 : 1
+      podDisruptionBudget = {
+        enabled        = true
+        maxUnavailable = 1
+      }
+      nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
+      tolerations = [
+        {
+          key      = "node-role.kubernetes.io/control-plane"
+          effect   = "NoSchedule"
+          operator = "Exists"
+        }
+      ]
+    }),
     yamlencode(var.cert_manager_webhook_hetzner_helm_values)
   ]
 }
@@ -57,10 +33,6 @@ data "helm_template" "cert_manager_webhook_hetzner" {
 locals {
   cert_manager_webhook_hetzner_manifest = var.cert_manager_webhook_hetzner_enabled ? {
     name     = "cert-manager-webhook-hetzner"
-    contents = <<-EOF
-      ${yamlencode(local.cert_manager_webhook_hetzner_secret_manifest)}
-      ---
-      ${data.helm_template.cert_manager_webhook_hetzner[0].manifest}
-    EOF
+    contents = data.helm_template.cert_manager_webhook_hetzner[0].manifest
   } : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,7 @@ output "talosconfig_data" {
 output "talos_client_configuration" {
   description = "Detailed configuration data for the Talos client."
   value       = data.talos_client_configuration.this
+  sensitive   = true
 }
 
 output "talos_machine_secrets" {

--- a/talos_config_control_plane.tf
+++ b/talos_config_control_plane.tf
@@ -19,6 +19,7 @@ locals {
     local.longhorn_manifest != null ? [local.longhorn_manifest] : [],
     local.metrics_server_manifest != null ? [local.metrics_server_manifest] : [],
     local.cert_manager_manifest != null ? [local.cert_manager_manifest] : [],
+    local.cert_manager_webhook_hetzner_manifest != null ? [local.cert_manager_webhook_hetzner_manifest] : [],
     local.ingress_nginx_manifest != null ? [local.ingress_nginx_manifest] : [],
     local.cluster_autoscaler_manifest != null ? [local.cluster_autoscaler_manifest] : [],
     var.talos_extra_inline_manifests != null ? var.talos_extra_inline_manifests : [],

--- a/variables.tf
+++ b/variables.tf
@@ -1813,35 +1813,6 @@ variable "cert_manager_webhook_hetzner_group_name" {
   }
 }
 
-variable "cert_manager_webhook_hetzner_secret_name" {
-  type        = string
-  default     = "hetzner"
-  description = "Name of the Kubernetes Secret created in the cert-manager namespace for the Hetzner DNS API token."
-
-  validation {
-    condition     = can(regex("^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$", var.cert_manager_webhook_hetzner_secret_name))
-    error_message = "The Cert Manager Hetzner webhook secret name must be a valid Kubernetes resource name."
-  }
-}
-
-variable "cert_manager_webhook_hetzner_secret_key" {
-  type        = string
-  default     = "token"
-  description = "Key in the Kubernetes Secret created for the Hetzner DNS API token."
-
-  validation {
-    condition     = can(regex("^[A-Za-z0-9._-]+$", var.cert_manager_webhook_hetzner_secret_key))
-    error_message = "The Cert Manager Hetzner webhook secret key must contain only letters, numbers, dots, underscores, or hyphens."
-  }
-}
-
-variable "cert_manager_webhook_hetzner_token" {
-  type        = string
-  default     = null
-  description = "Optional Hetzner API token for the Cert Manager Hetzner webhook. Defaults to hcloud_token when unset."
-  sensitive   = true
-}
-
 
 # Ingress NGINX
 variable "ingress_nginx_helm_repository" {

--- a/variables.tf
+++ b/variables.tf
@@ -1767,6 +1767,81 @@ variable "cert_manager_enabled" {
   description = "Enables the deployment of cert-manager for managing TLS certificates."
 }
 
+variable "cert_manager_webhook_hetzner_helm_repository" {
+  type        = string
+  default     = "https://charts.hetzner.cloud"
+  description = "URL of the Helm repository where the Cert Manager Hetzner webhook chart is located."
+}
+
+variable "cert_manager_webhook_hetzner_helm_chart" {
+  type        = string
+  default     = "cert-manager-webhook-hetzner"
+  description = "Name of the Helm chart used for deploying the Cert Manager Hetzner webhook."
+}
+
+variable "cert_manager_webhook_hetzner_helm_version" {
+  type        = string
+  default     = "0.7.0"
+  description = "Version of the Cert Manager Hetzner webhook Helm chart to deploy."
+}
+
+variable "cert_manager_webhook_hetzner_helm_values" {
+  type        = any
+  default     = {}
+  description = "Custom Helm values for the Cert Manager Hetzner webhook chart deployment. These values will merge with and will override the default values provided by the Cert Manager Hetzner webhook Helm chart."
+}
+
+variable "cert_manager_webhook_hetzner_enabled" {
+  type        = bool
+  default     = false
+  description = "Enables the deployment of the Cert Manager Hetzner webhook for ACME DNS-01 challenges using Hetzner DNS."
+
+  validation {
+    condition     = var.cert_manager_webhook_hetzner_enabled ? var.cert_manager_enabled : true
+    error_message = "The Cert Manager Hetzner webhook can only be enabled if cert-manager is also enabled."
+  }
+}
+
+variable "cert_manager_webhook_hetzner_group_name" {
+  type        = string
+  default     = "acme.hetzner.com"
+  description = "API group name used by the Cert Manager Hetzner webhook. Issuer webhook solver configurations must use the same groupName."
+
+  validation {
+    condition     = can(regex("^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)*(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)$", var.cert_manager_webhook_hetzner_group_name))
+    error_message = "The Cert Manager Hetzner webhook group name must be a valid DNS subdomain."
+  }
+}
+
+variable "cert_manager_webhook_hetzner_secret_name" {
+  type        = string
+  default     = "hetzner"
+  description = "Name of the Kubernetes Secret created in the cert-manager namespace for the Hetzner DNS API token."
+
+  validation {
+    condition     = can(regex("^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$", var.cert_manager_webhook_hetzner_secret_name))
+    error_message = "The Cert Manager Hetzner webhook secret name must be a valid Kubernetes resource name."
+  }
+}
+
+variable "cert_manager_webhook_hetzner_secret_key" {
+  type        = string
+  default     = "token"
+  description = "Key in the Kubernetes Secret created for the Hetzner DNS API token."
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9._-]+$", var.cert_manager_webhook_hetzner_secret_key))
+    error_message = "The Cert Manager Hetzner webhook secret key must contain only letters, numbers, dots, underscores, or hyphens."
+  }
+}
+
+variable "cert_manager_webhook_hetzner_token" {
+  type        = string
+  default     = null
+  description = "Optional Hetzner API token for the Cert Manager Hetzner webhook. Defaults to hcloud_token when unset."
+  sensitive   = true
+}
+
 
 # Ingress NGINX
 variable "ingress_nginx_helm_repository" {


### PR DESCRIPTION
## Summary
- add optional cert-manager-webhook-hetzner deployment via the Hetzner Helm chart
- keep Hetzner DNS token secret management outside the module so users can provide least-privilege or per-project tokens
- document DNS-01 ClusterIssuer usage and mark the Talos client output sensitive for validation

## Testing
- tofu fmt -check -recursive
- tofu validate
- helm template cert-manager-webhook-hetzner cert-manager-webhook-hetzner --repo https://charts.hetzner.cloud --version 0.7.0 --namespace cert-manager --set groupName=acme.hetzner.com --set replicaCount=2 --set podDisruptionBudget.enabled=true --set podDisruptionBudget.maxUnavailable=1 >/dev/null