### PR TITLE
fix: wrap talos_member index in try() to prevent failure on destroy

### DIFF
--- a/server.tf
+++ b/server.tf
@@ -218,7 +218,7 @@ locals {
   ipv6_non_public_pattern = "^(::$|::1$|fe[89ab][0-9a-f]:|f[cd][0-9a-f]*:|ff[0-9a-f]*:|2001:db8:|::ffff:)"
 
   talos_discovery_cluster_autoscaler = var.cluster_autoscaler_discovery_enabled ? {
-    for m in jsondecode(data.external.talos_member[0].result.cluster_autoscaler) : m.spec.hostname => {
+    for m in try(jsondecode(data.external.talos_member[0].result.cluster_autoscaler), []) : m.spec.hostname => {
       nodepool = regex(local.cluster_autoscaler_hostname_pattern, m.spec.hostname)[0]
 
       private_ipv4_address = try(

--- a/server.tf
+++ b/server.tf
@@ -218,7 +218,7 @@ locals {
   ipv6_non_public_pattern = "^(::$|::1$|fe[89ab][0-9a-f]:|f[cd][0-9a-f]*:|ff[0-9a-f]*:|2001:db8:|::ffff:)"
 
   talos_discovery_cluster_autoscaler = var.cluster_autoscaler_discovery_enabled ? {
-    for m in try(jsondecode(data.external.talos_member[0].result.cluster_autoscaler), []) : m.spec.hostname => {
+    for m in jsondecode(try(data.external.talos_member[0].result.cluster_autoscaler), "[]") : m.spec.hostname => {
       nodepool = regex(local.cluster_autoscaler_hostname_pattern, m.spec.hostname)[0]
 
       private_ipv4_address = try(


### PR DESCRIPTION
**Problem**:

When running a `tofu destroy` or `terraform destroy` operation, the execution fails with the following error:

```bash
 │ Error: Invalid index
 │ 
 │   on .terraform/modules/kubernetes/server.tf line 221, in locals:
 │  221:     for m in jsondecode(data.external.talos_member[0].result.cluster_autoscaler) : m.spec.hostname => {
 │     ├────────────────
 │     │ data.external.talos_member is empty tuple
 │ 
 │ The given key does not identify an element in this collection value: the collection has no elements.
```

This error occurs regardless of whether `var.cluster_autoscaler_discovery_enabled` is set to `true `or `false`.

**Cause:**

1. **Eager Evaluation:** Terraform and OpenTofu evaluate both branches of a conditional ternary expression (`condition ? true_val : false_val`) during the planning/validation phase to check types. If `var.cluster_autoscaler_discovery_enabled` is `false`, `data.external.talos_member` has a count of `0`. Evaluating `[0]` on an empty tuple throws an invalid index error.

2. **Destroy Lifecycle:** During a destruction phase, data sources are often torn down or removed from the state early in the dependency graph. This turns `data.external.talos_member` into an empty tuple mid-destroy, crashing the evaluation of the `locals `block even if the variable was originally set to true.

**Solution:**

This PR wraps the index access and decoding logic in a `try()` function, defaulting to an empty array `[]` if the index does not exist:

```hcl
talos_discovery_cluster_autoscaler = var.cluster_autoscaler_discovery_enabled ? {
  for m in try(jsondecode(data.external.talos_member[0].result.cluster_autoscaler), []) : m.spec.hostname => {
    nodepool = regex(local.cluster_autoscaler_hostname_pattern, m.spec.hostname)[0]
```

This ensures that:

- During Apply (Enabled): The data source loads correctly, the try() block succeeds, and the map evaluates normally.

- During Apply (Disabled): The missing index error is caught, falling back to [], resulting in a safe empty map {}.

- During Destroy: The lifecycle-induced empty tuple error is caught cleanly, allowing the destruction pipeline to finish successfully.

**Minimal Reproduction:**

```hcl
module "kubernetes" {
  source  = "hcloud-k8s/kubernetes/hcloud"
  version = "~>4.3.0"

  hcloud_token             = var.hcloud_token
  cluster_name             = "name"
  cluster_talosconfig_path = "talosconfig"
  cluster_kubeconfig_path  = "kubeconfig"

  control_plane_nodepools = [
    { name = "control", type = "cx23", location = "nbg1", count = 1 }
  ]
  worker_nodepools = [
    { name = "worker", type = "cx33", location = "nbg1", count = 3 }
  ]
}
```

1. Initialize the module with a standard working configuration.

2. Run `tofu destroy` or `terraform destroy`.
 
3. Observe that the process now proceeds to completion instead of halting on the locals block index validation.