### PR TITLE
refactor(talos): change lifecycle to ignore talos_version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,10 @@ Apply this change before proceeding. Once the delete protection is disabled, you
 
 **Terraform:**
 ```sh
-terraform state rm 'module.kubernetes.talos_machine_secrets.this'
 terraform destroy
 ```
 **OpenTofu:**
 ```sh
-tofu state rm 'module.kubernetes.talos_machine_secrets.this'
 tofu destroy
 ```
 

--- a/talos.tf
+++ b/talos.tf
@@ -99,7 +99,7 @@ resource "talos_machine_secrets" "this" {
   talos_version = var.talos_version
 
   lifecycle {
-    prevent_destroy = true
+    ignore_changes = [talos_version]
   }
 }
 


### PR DESCRIPTION
This pull request updates the management of the `talos_machine_secrets` resource and simplifies the destruction process in the documentation. The main changes are:

Resource lifecycle management:

* Changed the `lifecycle` block in the `talos_machine_secrets.this` resource to use `ignore_changes = [talos_version]` instead of `prevent_destroy = true`, allowing the resource to be destroyed and making version changes easier to manage.

Documentation simplification:

* Removed the `terraform state rm` and `tofu state rm` commands from the destruction instructions in `README.md`, streamlining the process for users.