### PR TITLE
Fix cluster_allow_scheduling_on_control_planes not respected by system components

### DIFF
--- a/cert_manager.tf
+++ b/cert_manager.tf
@@ -40,14 +40,16 @@ locals {
         matchLabelKeys = ["pod-template-hash"]
       }
     ],
-    nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
-    tolerations = [
+    nodeSelector = var.cluster_allow_scheduling_on_control_planes ? {
+          "node-role.kubernetes.io/control-plane" : ""
+      } : {}
+    tolerations = var.cluster_allow_scheduling_on_control_planes ? [
       {
         key      = "node-role.kubernetes.io/control-plane"
         effect   = "NoSchedule"
         operator = "Exists"
       }
-    ]
+    ] : []
   }
 }
 

--- a/cilium.tf
+++ b/cilium.tf
@@ -125,7 +125,9 @@ data "helm_template" "cilium" {
         }
       }
       operator = {
-        nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
+        nodeSelector = var.cluster_allow_scheduling_on_control_planes ? {
+          "node-role.kubernetes.io/control-plane" : ""
+        } : {}
         replicas     = local.control_plane_sum > 1 ? 2 : 1
         podDisruptionBudget = {
           enabled        = true

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -80,14 +80,16 @@ data "helm_template" "cluster_autoscaler" {
           matchLabelKeys = ["pod-template-hash"]
         }
       ]
-      nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
-      tolerations = [
+      nodeSelector = var.cluster_allow_scheduling_on_control_planes ? {
+          "node-role.kubernetes.io/control-plane" : ""
+      } : {}
+      tolerations = var.cluster_allow_scheduling_on_control_planes ? [
         {
           key      = "node-role.kubernetes.io/control-plane"
           effect   = "NoSchedule"
           operator = "Exists"
         }
-      ]
+      ] : []
       autoscalingGroups = [
         for np in local.cluster_autoscaler_nodepools : {
           name         = "${var.cluster_name}-${np.name}"

--- a/hcloud.tf
+++ b/hcloud.tf
@@ -155,14 +155,16 @@ data "helm_template" "hcloud_csi" {
             matchLabelKeys = ["pod-template-hash"]
           }
         ]
-        nodeSelector = { "node-role.kubernetes.io/control-plane" : "" }
-        tolerations = [
+        nodeSelector = var.cluster_allow_scheduling_on_control_planes ? {
+          "node-role.kubernetes.io/control-plane" : ""
+        } : {}
+        tolerations = var.cluster_allow_scheduling_on_control_planes ? [
           {
             key      = "node-role.kubernetes.io/control-plane"
             effect   = "NoSchedule"
             operator = "Exists"
           }
-        ]
+        ] : []
         volumeExtraLabels = var.hcloud_csi_volume_extra_labels
       }
       storageClasses = local.hcloud_csi_storage_classes


### PR DESCRIPTION
Closes #422

### Problem

The `cluster_allow_scheduling_on_control_planes` variable was not being respected by several system components. Their `nodeSelector` and `tolerations` were hardcoded to target control plane nodes, meaning the variable had no effect on their actual scheduling behavior.

### Changes

The following components have been updated to conditionally set `nodeSelector` and `tolerations` based on `cluster_allow_scheduling_on_control_planes`:

- **Cilium** (`cilium.tf`) — operator scheduling
- **Cert Manager** (`cert_manager.tf`)
- **Hetzner CSI** (`hcloud.tf`) — CSI controller values
- **Cluster Autoscaler** (`cluster_autoscaler.tf`)

When `cluster_allow_scheduling_on_control_planes = false`, these components now receive empty `nodeSelector` and `tolerations`, allowing the scheduler to place them on nodes of the users' choosing.

Note: The CCM is intentionally excluded as it is considered part of the control plane.