### PR TITLE
feat(network): refactor node subnet allocation to prevent shifting on removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ By default, this module calculates optimal subnets based on the provided network
     - **1st Half**: Allocated for internal special purpose subnets (`10.0.64.0/20` - `network_reserved_ipv4_cidr`)
       - `10.0.64.0/25`: Control Plane Nodes
       - `10.0.64.128/25`: Load Balancer
-      - `10.0.65.0 - 10.0.79.255`: Reserved (legacy Worker Node subnets)
+      - `10.0.65.0 - 10.0.79.255`: Reserved (Worker Node fixed subnets)
     - **2nd Half**: Allocated for Worker Nodes (`10.0.80.0/20` - `network_worker_nodes_ipv4_cidr`)
       - **1st Half**: Allocated for internal Worker Nodes (`10.0.80.0/21`)
         - `10.0.80.0/25`: Shared Worker Nodes subnet
@@ -809,12 +809,15 @@ Here is a table with more example calculations:
 | **10.0.0.0/19** | /28 (16 IPs)     | 10.0.8.0/22  (64) | 10.0.12.0/22 (1024) | 10.0.16.0/20 (16)   |
 | **10.0.0.0/20** | /29 (8 IPs)      | 10.0.4.0/23  (64) | 10.0.6.0/23 (512)   | 10.0.8.0/21 (8)     |
 | **10.0.0.0/21** | /30 (4 IPs)      | 10.0.2.0/24  (64) | 10.0.3.0/24 (256)   | 10.0.4.0/22 (4)     |
- 
+
 #### Explicit Subnet Allocation (`subnet_id`)
 
-By default, all new worker nodes share a single, unified node subnet to maximize IP availability and streamline routing. However, you can assign a custom `subnet_id` (0-29) to a specific worker nodepool to place its nodes into an explicitly allocated, isolated VPC subnet.
+By default, all worker nodes share a single, unified node subnet. However, you can assign a fixed subnet using the `subnet_id` (0-29) variable to a specific worker nodepool. This will place its nodes into an explicitly allocated subnet from the reserved legacy range (`network_reserved_ipv4_cidr`) instead of the default shared subnet.
 
-This feature relies on the reserved legacy subnet range (`network_reserved_ipv4_cidr`). Users with up to 30 worker node pools (using `/25` subnets in `10.0.65.0 - 10.0.79.255`) can migrate seamlessly using this option. In general, this option should be treated as a **legacy compatibility setting**, used only when strictly necessary, such as:
+This option is intended for backward compatibility with existing deployments or specific routing requirements.
+
+Users can declare up to 30 fixed subnets for worker node pools (using `/25` subnets in `10.0.65.0 - 10.0.79.255`). In general, this option is not recommended and should only be used when strictly necessary, such as:
+
 - Isolating traffic for specific legacy IP/CIDR firewall ACLs.
 - Maintaining IP assignments when migrating existing nodepools from older versions of this module to prevent nodes from being destroyed and recreated.
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ module "kubernetes" {
     { name = "control", type = "cpx22", location = "nbg1", count = 3 }
   ]
   worker_nodepools = [
-    { name = "worker", type = "cpx22", location = "nbg1", count = 3 }
+    { name = "worker", type = "cpx22", location = "nbg1", count = 3 },
+    { name = "segmented-pool", type = "cpx22", location = "fsn1", count = 1, subnet_id = 0 } # Useful for VPC segmentation or migrating existing pools
   ]
 }
 ```
@@ -760,14 +761,23 @@ Topology-aware routing in ingress-nginx can optionally be enabled by setting the
 <details>
 <summary><b>Network Segmentation</b></summary>
 
-By default, this module calculates optimal subnets based on the provided network CIDR (`network_ipv4_cidr`). The network is segmented automatically as follows:
+By default, this module calculates optimal subnets based on the provided network CIDR (`network_ipv4_cidr`). The network is segmented automatically as follows (example using the default `10.0.0.0/16`):
 
-- **1st Quarter**: Reserved for other uses such as classic VMs.
+- **1st Quarter**: Reserved for other uses such as classic VMs (`10.0.0.0/18`)
 - **2nd Quarter**:
-  - **1st Half**: Allocated for Node Subnets (`network_node_ipv4_cidr`)
-  - **2nd Half**: Allocated for Service IPs (`network_service_ipv4_cidr`)
+  - **1st Half**: Allocated for Node subnets (`10.0.64.0/19` - `network_node_ipv4_cidr`)
+    - **1st Half**: Allocated for internal special purpose subnets (`10.0.64.0/20` - `network_reserved_ipv4_cidr`)
+      - `10.0.64.0/25`: Control Plane Nodes
+      - `10.0.64.128/25`: Load Balancer
+      - `10.0.65.0 - 10.0.79.255`: Reserved (legacy Worker Node subnets)
+    - **2nd Half**: Allocated for Worker Nodes (`10.0.80.0/20` - `network_worker_nodes_ipv4_cidr`)
+      - **1st Half**: Allocated for internal Worker Nodes (`10.0.80.0/21`)
+        - `10.0.80.0/25`: Shared Worker Nodes subnet
+        - `10.0.80.128/25`: Shared Cluster Autoscaler subnet
+      - **2nd Half**: Allocated for external (vSwitch) Worker Nodes (`10.0.88.0/21`)
+  - **2nd Half**: Allocated for Service IPs (`10.0.96.0/19` - `network_service_ipv4_cidr`)
 - **3rd and 4th Quarters**:
-  - **Full Span**: Allocated for Pod Subnets (`network_pod_ipv4_cidr`)
+  - **Full Span**: Allocated for Pod Subnets (`10.0.128.0/17` - `network_pod_ipv4_cidr`) with a default `/24` per node
 
 Each Kubernetes node requires a `/24` subnet within `network_pod_ipv4_cidr`. To support this configuration, the optimal node subnet size (`network_node_ipv4_subnet_mask_size`) is calculated using the formula:<br>
 32 - (24 - subnet_mask_size(`network_pod_ipv4_cidr`)).
@@ -800,6 +810,23 @@ Here is a table with more example calculations:
 | **10.0.0.0/20** | /29 (8 IPs)      | 10.0.4.0/23  (64) | 10.0.6.0/23 (512)   | 10.0.8.0/21 (8)     |
 | **10.0.0.0/21** | /30 (4 IPs)      | 10.0.2.0/24  (64) | 10.0.3.0/24 (256)   | 10.0.4.0/22 (4)     |
  
+#### Explicit Subnet Allocation (`subnet_id`)
+
+By default, all new worker nodes share a single, unified node subnet to maximize IP availability and streamline routing. However, you can assign a custom `subnet_id` (0-29) to a specific worker nodepool to place its nodes into an explicitly allocated, isolated VPC subnet.
+
+This feature relies on the reserved legacy subnet range (`network_reserved_ipv4_cidr`). Users with up to 30 worker node pools (using `/25` subnets in `10.0.65.0 - 10.0.79.255`) can migrate seamlessly using this option. In general, this option should be treated as a **legacy compatibility setting**, used only when strictly necessary, such as:
+- Isolating traffic for specific legacy IP/CIDR firewall ACLs.
+- Maintaining IP assignments when migrating existing nodepools from older versions of this module to prevent nodes from being destroyed and recreated.
+
+> [!TIP]
+> When migrating existing worker nodepools from older versions of this module, set the `subnet_id` to match the exact 0-based index the nodepool held in your original `worker_nodepools` list. For example, the first pool in your list should get `subnet_id = 0`, the second `subnet_id = 1`, and so on.
+
+Example:
+```hcl
+worker_nodepools = [
+  { name = "isolated-pool", type = "cpx22", location = "fsn1", count = 1, subnet_id = 4 }
+]
+```
 </details>
 
 

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -22,10 +22,11 @@ locals {
             arm64 = local.image_label_selector,
             amd64 = local.image_label_selector
           },
+          defaultSubnetIPRange = hcloud_network_subnet.autoscaler_shared.ip_range,
           nodeConfigs = {
             for nodepool in local.cluster_autoscaler_nodepools : "${var.cluster_name}-${nodepool.name}" => {
               cloudInit = data.talos_machine_configuration.cluster_autoscaler[nodepool.name].machine_configuration,
-              labels    = nodepool.labels
+              labels    = nodepool.labels,
               taints    = nodepool.taints
             }
           }

--- a/network.tf
+++ b/network.tf
@@ -8,8 +8,7 @@ locals {
   # Network ranges
   network_ipv4_cidr             = length(data.hcloud_network.this) > 0 ? data.hcloud_network.this[0].ip_range : var.network_ipv4_cidr
   network_ipv4_cidr_prefix_size = tonumber(split("/", local.network_ipv4_cidr)[1])
-
-  network_node_ipv4_cidr = coalesce(var.network_node_ipv4_cidr, cidrsubnet(local.network_ipv4_cidr, 3, 2))
+  network_node_ipv4_cidr        = coalesce(var.network_node_ipv4_cidr, cidrsubnet(local.network_ipv4_cidr, 3, 2))
 
   # Limit service IPs to a /12 or more specific CIDR to satisfy Kubernetes 1.33+ validation.
   network_service_ipv4_cidr_newbits = max(3, 12 - local.network_ipv4_cidr_prefix_size)
@@ -36,6 +35,11 @@ locals {
     var.network_node_ipv4_subnet_mask_size,
     32 - (local.network_pod_ipv4_subnet_mask_size - split("/", local.network_pod_ipv4_cidr)[1])
   )
+
+  # Node Subnet allocations
+  network_reserved_ipv4_cidr       = cidrsubnet(local.network_node_ipv4_cidr, 1, 0)
+  network_worker_nodes_ipv4_cidr   = cidrsubnet(local.network_node_ipv4_cidr, 1, 1)
+  network_node_ipv4_subnet_newbits = local.network_node_ipv4_subnet_mask_size - (split("/", local.network_node_ipv4_cidr)[1] + 1)
 
   # Lists for control plane nodes
   control_plane_public_ipv4_list  = compact(distinct([for server in hcloud_server.control_plane : server.ipv4_address]))
@@ -85,8 +89,8 @@ resource "hcloud_network_subnet" "control_plane" {
   network_zone = local.hcloud_network_zone
 
   ip_range = cidrsubnet(
-    local.network_node_ipv4_cidr,
-    local.network_node_ipv4_subnet_mask_size - split("/", local.network_node_ipv4_cidr)[1],
+    local.network_reserved_ipv4_cidr,
+    local.network_node_ipv4_subnet_newbits,
     0 + (local.network_node_ipv4_cidr_skip_first_subnet ? 1 : 0)
   )
 }
@@ -97,23 +101,35 @@ resource "hcloud_network_subnet" "load_balancer" {
   network_zone = local.hcloud_network_zone
 
   ip_range = cidrsubnet(
-    local.network_node_ipv4_cidr,
-    local.network_node_ipv4_subnet_mask_size - split("/", local.network_node_ipv4_cidr)[1],
+    local.network_reserved_ipv4_cidr,
+    local.network_node_ipv4_subnet_newbits,
     1 + (local.network_node_ipv4_cidr_skip_first_subnet ? 1 : 0)
   )
 }
 
+resource "hcloud_network_subnet" "worker_shared" {
+  network_id   = local.hcloud_network_id
+  type         = "cloud"
+  network_zone = local.hcloud_network_zone
+
+  ip_range = cidrsubnet(
+    local.network_worker_nodes_ipv4_cidr,
+    local.network_node_ipv4_subnet_newbits,
+    0 + (local.network_node_ipv4_cidr_skip_first_subnet ? 1 : 0)
+  )
+}
+
 resource "hcloud_network_subnet" "worker" {
-  for_each = { for np in local.worker_nodepools : np.name => np }
+  for_each = { for np in local.worker_nodepools : np.name => np if np.subnet_id != null }
 
   network_id   = local.hcloud_network_id
   type         = "cloud"
   network_zone = local.hcloud_network_zone
 
   ip_range = cidrsubnet(
-    local.network_node_ipv4_cidr,
-    local.network_node_ipv4_subnet_mask_size - split("/", local.network_node_ipv4_cidr)[1],
-    2 + (local.network_node_ipv4_cidr_skip_first_subnet ? 1 : 0) + index(local.worker_nodepools, each.value)
+    local.network_reserved_ipv4_cidr,
+    local.network_node_ipv4_subnet_newbits,
+    2 + (local.network_node_ipv4_cidr_skip_first_subnet ? 1 : 0) + each.value.subnet_id
   )
 }
 
@@ -131,6 +147,26 @@ resource "hcloud_network_subnet" "autoscaler" {
   depends_on = [
     hcloud_network_subnet.control_plane,
     hcloud_network_subnet.load_balancer,
+    hcloud_network_subnet.worker_shared,
+    hcloud_network_subnet.worker
+  ]
+}
+
+resource "hcloud_network_subnet" "autoscaler_shared" {
+  network_id   = local.hcloud_network_id
+  type         = "cloud"
+  network_zone = local.hcloud_network_zone
+
+  ip_range = cidrsubnet(
+    local.network_worker_nodes_ipv4_cidr,
+    local.network_node_ipv4_subnet_newbits,
+    1 + (local.network_node_ipv4_cidr_skip_first_subnet ? 1 : 0)
+  )
+
+  depends_on = [
+    hcloud_network_subnet.control_plane,
+    hcloud_network_subnet.load_balancer,
+    hcloud_network_subnet.worker_shared,
     hcloud_network_subnet.worker
   ]
 }

--- a/nodepool.tf
+++ b/nodepool.tf
@@ -61,7 +61,8 @@ locals {
         taint
       )],
       count           = np.count,
-      placement_group = np.placement_group
+      placement_group = np.placement_group,
+      subnet_id       = np.subnet_id
     }
   ]
 

--- a/server.tf
+++ b/server.tf
@@ -8,11 +8,7 @@ resource "hcloud_server" "control_plane" {
         keep_disk          = local.control_plane_nodepools[np_index].keep_disk,
         labels             = local.control_plane_nodepools[np_index].labels,
         placement_group_id = hcloud_placement_group.control_plane.id,
-        subnet             = hcloud_network_subnet.control_plane,
-        ipv4_private = cidrhost(
-          hcloud_network_subnet.control_plane.ip_range,
-          np_index * 10 + cp_index + 1
-        )
+        subnet             = hcloud_network_subnet.control_plane
       }
     }
   ]...)
@@ -46,8 +42,8 @@ resource "hcloud_server" "control_plane" {
   }
 
   network {
-    network_id = each.value.subnet.network_id
-    ip         = each.value.ipv4_private
+    network_id = local.hcloud_network_id
+    subnet_id  = each.value.subnet.id
     alias_ips  = []
   }
 
@@ -77,8 +73,7 @@ resource "hcloud_server" "worker" {
         keep_disk          = local.worker_nodepools[np_index].keep_disk,
         labels             = local.worker_nodepools[np_index].labels,
         placement_group_id = local.worker_nodepools[np_index].placement_group ? hcloud_placement_group.worker["${var.cluster_name}-${local.worker_nodepools[np_index].name}-pg-${ceil((wkr_index + 1) / 10.0)}"].id : null,
-        subnet             = hcloud_network_subnet.worker[local.worker_nodepools[np_index].name],
-        ipv4_private       = cidrhost(hcloud_network_subnet.worker[local.worker_nodepools[np_index].name].ip_range, wkr_index + 1)
+        subnet_id          = local.worker_nodepools[np_index].subnet_id != null ? hcloud_network_subnet.worker[local.worker_nodepools[np_index].name].id : hcloud_network_subnet.worker_shared.id
       }
     }
   ]...)
@@ -112,13 +107,14 @@ resource "hcloud_server" "worker" {
   }
 
   network {
-    network_id = each.value.subnet.network_id
-    ip         = each.value.ipv4_private
+    network_id = local.hcloud_network_id
+    subnet_id  = each.value.subnet_id
     alias_ips  = []
   }
 
   depends_on = [
     terraform_data.hcloud_server_cluster_autoscaler,
+    hcloud_network_subnet.worker_shared,
     hcloud_network_subnet.worker,
     hcloud_placement_group.worker
   ]
@@ -127,7 +123,8 @@ resource "hcloud_server" "worker" {
     ignore_changes = [
       image,
       user_data,
-      ssh_keys
+      ssh_keys,
+      network
     ]
   }
 }

--- a/talos.tf
+++ b/talos.tf
@@ -249,7 +249,8 @@ resource "talos_machine_configuration_apply" "control_plane" {
     network      = s.network
     ipv4_address = s.ipv4_address
     ipv6_address = s.ipv6_address
-  } }
+    }
+  }
 
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.control_plane[each.key].machine_configuration
@@ -305,7 +306,8 @@ resource "talos_machine_configuration_apply" "worker" {
     network      = s.network
     ipv4_address = s.ipv4_address
     ipv6_address = s.ipv6_address
-  } }
+    }
+  }
 
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.worker[each.key].machine_configuration

--- a/talos.tf
+++ b/talos.tf
@@ -245,7 +245,11 @@ resource "terraform_data" "upgrade_kubernetes" {
 }
 
 resource "talos_machine_configuration_apply" "control_plane" {
-  for_each = { for control_plane in hcloud_server.control_plane : control_plane.name => control_plane }
+  for_each = { for s in hcloud_server.control_plane : s.name => {
+    network      = s.network
+    ipv4_address = s.ipv4_address
+    ipv6_address = s.ipv6_address
+  } }
 
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.control_plane[each.key].machine_configuration
@@ -297,7 +301,11 @@ resource "terraform_data" "talos_staged_configuration_reboot_control_plane" {
 }
 
 resource "talos_machine_configuration_apply" "worker" {
-  for_each = { for worker in hcloud_server.worker : worker.name => worker }
+  for_each = { for s in hcloud_server.worker : s.name => {
+    network      = s.network
+    ipv4_address = s.ipv4_address
+    ipv6_address = s.ipv6_address
+  } }
 
   client_configuration        = talos_machine_secrets.this.client_configuration
   machine_configuration_input = data.talos_machine_configuration.worker[each.key].machine_configuration

--- a/talos_config_control_plane.tf
+++ b/talos_config_control_plane.tf
@@ -170,7 +170,7 @@ locals {
 }
 
 data "talos_machine_configuration" "control_plane" {
-  for_each = { for node in hcloud_server.control_plane : node.name => node }
+  for_each = toset([for node in hcloud_server.control_plane : node.name])
 
   talos_version      = var.talos_version
   cluster_name       = var.cluster_name

--- a/talos_config_worker.tf
+++ b/talos_config_worker.tf
@@ -40,7 +40,7 @@ locals {
 }
 
 data "talos_machine_configuration" "worker" {
-  for_each = { for node in hcloud_server.worker : node.name => node }
+  for_each = toset([for node in hcloud_server.worker : node.name])
 
   talos_version      = var.talos_version
   cluster_name       = var.cluster_name

--- a/terraform.tf
+++ b/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.62.0"
+      version = "1.64.0"
     }
 
     helm = {

--- a/variables.tf
+++ b/variables.tf
@@ -375,6 +375,7 @@ variable "worker_nodepools" {
     rdns_ipv4       = optional(string)
     rdns_ipv6       = optional(string)
     placement_group = optional(bool, true)
+    subnet_id       = optional(number)
   }))
   default     = []
   description = "Defines configuration settings for Worker node pools within the cluster."
@@ -382,6 +383,18 @@ variable "worker_nodepools" {
   validation {
     condition     = length(var.worker_nodepools) == length(distinct([for np in var.worker_nodepools : np.name]))
     error_message = "Worker nodepool names must be unique to avoid configuration conflicts."
+  }
+
+  validation {
+    condition = alltrue([
+      for np in var.worker_nodepools : np.subnet_id == null || (np.subnet_id != null && np.subnet_id >= 0 && np.subnet_id <= 29)
+    ])
+    error_message = "The subnet_id must be between 0 and 29 to fit within the reserved special purpose network block."
+  }
+
+  validation {
+    condition = length([for np in var.worker_nodepools : np.subnet_id if np.subnet_id != null]) == length(distinct([for np in var.worker_nodepools : np.subnet_id if np.subnet_id != null]))
+    error_message = "Worker nodepools cannot share the same subnet_id. Each subnet_id maps to a strict 1-to-1 isolated subnet. If you want nodepools to share a subnet, omit the subnet_id to use the default worker_shared subnet."
   }
 
   validation {
@@ -452,7 +465,7 @@ variable "cluster_autoscaler_helm_chart" {
 
 variable "cluster_autoscaler_helm_version" {
   type        = string
-  default     = "9.50.1"
+  default     = "9.57.0"
   description = "Version of the Cluster Autoscaler Helm chart to deploy."
 }
 
@@ -464,7 +477,7 @@ variable "cluster_autoscaler_helm_values" {
 
 variable "cluster_autoscaler_image_tag" {
   type        = string
-  default     = "v1.33.4"
+  default     = "v1.35.0"
   description = "Version of the Cluster Autoscaler Image."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -393,7 +393,7 @@ variable "worker_nodepools" {
   }
 
   validation {
-    condition = length([for np in var.worker_nodepools : np.subnet_id if np.subnet_id != null]) == length(distinct([for np in var.worker_nodepools : np.subnet_id if np.subnet_id != null]))
+    condition     = length([for np in var.worker_nodepools : np.subnet_id if np.subnet_id != null]) == length(distinct([for np in var.worker_nodepools : np.subnet_id if np.subnet_id != null]))
     error_message = "Worker nodepools cannot share the same subnet_id. Each subnet_id maps to a strict 1-to-1 isolated subnet. If you want nodepools to share a subnet, omit the subnet_id to use the default worker_shared subnet."
   }
 


### PR DESCRIPTION
Hi @M4t7e 
Hope everything is going well :grin: 
This PR fixes #163

## Summary                                                                                                                       
                                                                                                                                         
Redesigns the internal subnetting layout to prevent dangerous Terraform state changes that previously shifted IP ranges and rebuilt nodes when an intermediate worker nodepool was removed.
Follows the implementation plan you shared [here](https://github.com/hcloud-k8s/terraform-hcloud-kubernetes/issues/163#issuecomment-3930711870).                                
                                                                                                                                         
### Changes                                                                                              
- Introduces `worker_shared` and `autoscaler_shared` subnets to seamlessly consolidate new node provisioning into a resilient, shared VPC segment.                                                                                                                           
- Drops manual `ipv4_private` CIDR math in favor of relying purely on Hetzner's API for dynamic IP auto-assignment.   
- Adds `subnet_id` (0-29) to `worker_nodepools` as an optional parameter to enforce fixed/isolated VPC subnets, maintaining 100%     backward compatibility for migrating legacy nodepools.                                                                                 
- Adds a validation rule to ensure `subnet_id` fixed allocations are unique per nodepool.
- Updates `README.md` to document the new allocation layout, CIDR tree, and fixed subnet usage.
- Removed `datacenter` field deprecation warnings
- Upgrades Cluster Autoscaler to v1.35.0 (Required for this to work with autoscaler nodes)