### PR TITLE
Revert "chore(deps): update terraform hcloud to v1.66.0"

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -9,7 +9,7 @@ terraform {
 
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.66.0"
+      version = "1.65.0"
     }
 
     helm = {


### PR DESCRIPTION
Reverts hcloud-k8s/terraform-hcloud-kubernetes#452 because of https://github.com/hetznercloud/terraform-provider-hcloud/issues/1478