### PR TITLE
feat(talos): allow retaining unpacked CRI image layers

### DIFF
--- a/talos_config_base.tf
+++ b/talos_config_base.tf
@@ -79,6 +79,24 @@ locals {
     }
   }
 
+  # CRI Configuration
+  talos_cri_config_patches = !var.talos_cri_discard_unpacked_layers ? [
+    {
+      machine = {
+        files = [
+          {
+            path    = "/etc/cri/conf.d/20-customization.part"
+            op      = "create"
+            content = <<-EOT
+              [plugins."io.containerd.cri.v1.images"]
+                discard_unpacked_layers = false
+            EOT
+          }
+        ]
+      }
+    }
+  ] : []
+
   # Public Network Link Config
   talos_cloud_public_link_config_patches = local.talos_public_interface_enabled ? [
     {
@@ -285,7 +303,8 @@ locals {
     [local.talos_resolver_config_patch],
     [local.talos_time_sync_config_patch],
     local.talos_static_host_config_patches,
-    local.talos_trusted_certs_config_patches
+    local.talos_trusted_certs_config_patches,
+    local.talos_cri_config_patches
   )
 
   talos_cloud_config_patches = concat(

--- a/variables.tf
+++ b/variables.tf
@@ -830,6 +830,12 @@ variable "talos_discovery_service_enabled" {
   description = "Enable or disable Sidero Labs public Talos discovery service."
 }
 
+variable "talos_cri_discard_unpacked_layers" {
+  type        = bool
+  default     = true
+  description = "Determines whether containerd discards unpacked image layers on all Talos nodes. Set to false to retain unpacked image layers. Attention: Changing this value forces all Talos nodes to reboot and should be performed with `talos_machine_configuration_apply_mode = \"staged\"`."
+}
+
 variable "talos_kubelet_extra_mounts" {
   type = list(object({
     source      = string


### PR DESCRIPTION
This PR introduces a new option that controls whether containerd discards unpacked image layers on all Talos nodes. This is useful for workloads that require access to the original image layers, such as running [Spegel on Talos](https://docs.siderolabs.com/kubernetes-guides/advanced-guides/spegel).

By default, unpacked layers continue to be discarded. This behavior can now be disabled cluster-wide through a variable. Changing the option requires all Talos nodes to reboot, so it should be changed with `staged` apply mode.