### PR TITLE
feat(image): add configurable Talos cloud image selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Talos Linux is a secure, minimal, and immutable OS for Kubernetes, removing SSH 
 ### ✅ Prerequisites
 
 - [terraform](https://developer.hashicorp.com/terraform/install) or [tofu](https://opentofu.org/docs/intro/install/) to deploy the Cluster
-- [packer](https://developer.hashicorp.com/packer/install) to upload Talos Images
+- [packer](https://developer.hashicorp.com/packer/install) to upload Talos Images when cloud image building is enabled
 - [curl](https://curl.se) and [jq](https://jqlang.org/download/) for API Communication
 - [talosctl](https://www.talos.dev/latest/talos-guides/install/talosctl) to control the Talos Cluster
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) to control Kubernetes (optional)
@@ -1067,6 +1067,45 @@ talos_backup_schedule = "0 * * * *"
 ```
 
 To recover from a snapshot, please refer to the Talos Disaster Recovery section in the [Documentation](https://www.talos.dev/latest/advanced/disaster-recovery/#recovery).
+</details>
+
+<!-- Talos Cloud Images -->
+<details>
+<summary><b>Talos Cloud Images</b></summary>
+
+By default, the module builds missing AMD64 and ARM64 Talos snapshots with Packer and selects images whose labels exactly match the cluster name, Talos version, and schematic ID. Image building and selection can be configured independently for each architecture:
+
+```hcl
+talos_cloud_amd64_image_build_enabled = true
+talos_cloud_amd64_image_selector      = "exact"
+
+talos_cloud_arm64_image_build_enabled = true
+talos_cloud_arm64_image_selector      = "exact"
+```
+
+The supported selector values are:
+
+- `exact`: Selects an image matching the cluster name, Talos version, and schematic ID.
+- `latest`: Selects the newest image matching only the cluster name and architecture.
+
+Disabling an image builder is useful when matching snapshots are created outside this module. For example:
+
+```hcl
+talos_cloud_arm64_image_build_enabled = false
+talos_cloud_arm64_image_selector      = "exact"
+```
+
+If no exactly matching snapshot exists, the lookup fails instead of silently selecting an older image.
+
+To disable the ARM64 builder and explicitly select the newest existing cluster snapshot:
+
+```hcl
+talos_cloud_arm64_image_build_enabled = false
+talos_cloud_arm64_image_selector      = "latest"
+```
+
+> ⚠️ **Warning:** The `latest` selector is strongly discouraged and unsupported. It ignores the configured Talos version and schematic ID, so new nodes may boot with incompatible Talos versions, system extensions, or kernel arguments. This can cause bootstrap failures, unavailable nodes, or cluster disruption. It is not an officially supported recovery or emergency mechanism. Use it entirely at your own risk.
+
 </details>
 
 

--- a/client.tf
+++ b/client.tf
@@ -136,7 +136,7 @@ data "external" "client_prerequisites_check" {
 
       missing=0
 
-      if ! command -v packer >/dev/null 2>&1; then
+      if [ "${local.talos_cloud_image_build_required}" = "true" ] && ! command -v packer >/dev/null 2>&1; then
           printf '\n%s' ' - packer is not installed or not in PATH. Install it at https://developer.hashicorp.com/packer/install' >&2
           missing=1
       fi

--- a/cluster_autoscaler.tf
+++ b/cluster_autoscaler.tf
@@ -18,8 +18,8 @@ locals {
       cluster-config = base64encode(jsonencode(
         {
           imagesForArch = {
-            arm64 = local.talos_image_label_selector,
-            amd64 = local.talos_image_label_selector
+            arm64 = local.talos_cloud_arm64_image_label_selector,
+            amd64 = local.talos_cloud_amd64_image_label_selector
           },
           defaultSubnetIPRange = hcloud_network_subnet.cluster_autoscaler_shared.ip_range,
           nodeConfigs = {

--- a/image.tf
+++ b/image.tf
@@ -38,13 +38,34 @@ locals {
     ) : can(regex(local.cloud_arm64_server_type_pattern, np.server_type))
   ])
 
-  talos_image_label_selector = join(",",
+  cloud_amd64_image_build_required = local.cloud_amd64_image_required && var.talos_cloud_amd64_image_build_enabled
+  cloud_arm64_image_build_required = local.cloud_arm64_image_required && var.talos_cloud_arm64_image_build_enabled
+  talos_cloud_image_build_required = local.cloud_amd64_image_build_required || local.cloud_arm64_image_build_required
+
+  talos_image_label_selector_exact = join(",",
     [
       "os=talos",
       "cluster=${var.cluster_name}",
       "talos_version=${var.talos_version}",
       "talos_schematic_id=${substr(local.talos_cloud_schematic_id, 0, 32)}"
     ]
+  )
+  talos_image_label_selector_latest = join(",",
+    [
+      "os=talos",
+      "cluster=${var.cluster_name}"
+    ]
+  )
+
+  talos_cloud_amd64_image_label_selector = (
+    var.talos_cloud_amd64_image_selector == "latest" ?
+    local.talos_image_label_selector_latest :
+    local.talos_image_label_selector_exact
+  )
+  talos_cloud_arm64_image_label_selector = (
+    var.talos_cloud_arm64_image_selector == "latest" ?
+    local.talos_image_label_selector_latest :
+    local.talos_image_label_selector_exact
   )
 
   talos_image_extensions_longhorn = [
@@ -175,17 +196,17 @@ data "talos_image_factory_urls" "metal" {
 }
 
 data "hcloud_images" "amd64" {
-  count = local.cloud_amd64_image_required ? 1 : 0
+  count = local.cloud_amd64_image_build_required ? 1 : 0
 
-  with_selector     = local.talos_image_label_selector
+  with_selector     = local.talos_image_label_selector_exact
   with_architecture = ["x86"]
   most_recent       = true
 }
 
 data "hcloud_images" "arm64" {
-  count = local.cloud_arm64_image_required ? 1 : 0
+  count = local.cloud_arm64_image_build_required ? 1 : 0
 
-  with_selector     = local.talos_image_label_selector
+  with_selector     = local.talos_image_label_selector_exact
   with_architecture = ["arm"]
   most_recent       = true
 }
@@ -197,21 +218,22 @@ resource "terraform_data" "packer_init" {
     var.talos_version,
     local.talos_cloud_schematic_id,
     local.cloud_amd64_image_required,
-    local.cloud_arm64_image_required
+    local.cloud_arm64_image_required,
+    local.talos_cloud_image_build_required
   ]
 
   provisioner "local-exec" {
     when        = create
     quiet       = true
     working_dir = "${path.module}/packer/"
-    command     = "packer init -upgrade requirements.pkr.hcl"
+    command     = local.talos_cloud_image_build_required ? "packer init -upgrade requirements.pkr.hcl" : "true"
   }
 
   depends_on = [data.external.client_prerequisites_check]
 }
 
 resource "terraform_data" "amd64_image" {
-  count = local.cloud_amd64_image_required ? 1 : 0
+  count = local.cloud_amd64_image_build_required ? 1 : 0
 
   triggers_replace = [
     var.cluster_name,
@@ -248,7 +270,7 @@ resource "terraform_data" "amd64_image" {
 }
 
 resource "terraform_data" "arm64_image" {
-  count = local.cloud_arm64_image_required ? 1 : 0
+  count = local.cloud_arm64_image_build_required ? 1 : 0
 
   triggers_replace = [
     var.cluster_name,
@@ -287,7 +309,7 @@ resource "terraform_data" "arm64_image" {
 data "hcloud_image" "amd64" {
   count = local.cloud_amd64_image_required ? 1 : 0
 
-  with_selector     = local.talos_image_label_selector
+  with_selector     = local.talos_cloud_amd64_image_label_selector
   with_architecture = "x86"
   most_recent       = true
 
@@ -297,7 +319,7 @@ data "hcloud_image" "amd64" {
 data "hcloud_image" "arm64" {
   count = local.cloud_arm64_image_required ? 1 : 0
 
-  with_selector     = local.talos_image_label_selector
+  with_selector     = local.talos_cloud_arm64_image_label_selector
   with_architecture = "arm"
   most_recent       = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -746,6 +746,40 @@ variable "packer_arm64_builder" {
   }
 }
 
+variable "talos_cloud_amd64_image_build_enabled" {
+  type        = bool
+  default     = true
+  description = "Controls whether the module builds a missing Talos AMD64 cloud image with Packer. Disable this only when a suitable snapshot already exists in the Hetzner Cloud project."
+}
+
+variable "talos_cloud_amd64_image_selector" {
+  type        = string
+  default     = "exact"
+  description = "Selects the Talos AMD64 cloud image. 'exact' requires labels matching the cluster, Talos version, and schematic ID. WARNING: 'latest' selects the newest image for the cluster and architecture without matching the Talos version or schematic ID. It is strongly discouraged, entirely unsupported, and not an officially supported mechanism."
+
+  validation {
+    condition     = contains(["exact", "latest"], var.talos_cloud_amd64_image_selector)
+    error_message = "The talos_cloud_amd64_image_selector value must be one of: 'exact' or 'latest'."
+  }
+}
+
+variable "talos_cloud_arm64_image_build_enabled" {
+  type        = bool
+  default     = true
+  description = "Controls whether the module builds a missing Talos ARM64 cloud image with Packer. Disable this only when a suitable snapshot already exists in the Hetzner Cloud project."
+}
+
+variable "talos_cloud_arm64_image_selector" {
+  type        = string
+  default     = "exact"
+  description = "Selects the Talos ARM64 cloud image. 'exact' requires labels matching the cluster, Talos version, and schematic ID. WARNING: 'latest' selects the newest image for the cluster and architecture without matching the Talos version or schematic ID. It is strongly discouraged, entirely unsupported, and not an officially supported mechanism."
+
+  validation {
+    condition     = contains(["exact", "latest"], var.talos_cloud_arm64_image_selector)
+    error_message = "The talos_cloud_arm64_image_selector value must be one of: 'exact' or 'latest'."
+  }
+}
+
 
 # Talos
 variable "talos_version" {


### PR DESCRIPTION
Adds per-architecture controls for Talos cloud image building and selection.

The default `exact` behavior remains unchanged. The `latest` selector is unsupported and may select an image with a different Talos version or schematic ID. Bare-metal nodes are unaffected.

Closes #453