### PR TITLE
docs: restore the Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1441,11 +1441,11 @@ If you'd like to support this project, please consider leaving a ⭐ on GitHub!<
 </a>
 
 
-<!-- <picture>
- <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hcloud-k8s/terraform-hcloud-kubernetes&type=date&theme=dark&legend=top-left" />
- <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hcloud-k8s/terraform-hcloud-kubernetes&type=date&legend=top-left" />
- <img width="700" alt="Star History Chart" src="https://api.star-history.com/svg?repos=hcloud-k8s/terraform-hcloud-kubernetes&type=date&legend=top-left" />
-</picture> -->
+<picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=hcloud-k8s/terraform-hcloud-kubernetes&type=date&theme=dark&legend=top-left" />
+ <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=hcloud-k8s/terraform-hcloud-kubernetes&type=date&legend=top-left" />
+ <img width="700" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=hcloud-k8s/terraform-hcloud-kubernetes&type=date&legend=top-left" />
+</picture>
 
 > [!TIP]
 > If you don’t have a Hetzner account yet, you can use this [Hetzner Cloud Referral Link](https://hetzner.cloud/?ref=GMylKeDmqtsD) to claim a €20 credit and support this project at the same time.


### PR DESCRIPTION
The Star History chart was disabled in commit 572448c ("Update README.md") because it stopped loading. This has left the README without a chart for a while, which is a shame since it is a nice way for visitors to see how the project is growing. This change restores the chart with a working data source, so it renders correctly again. Fixing this is necessary because the current chart is broken and missing for everyone visiting the repository.