### PR TITLE
fix(firewall): keep the Robot rule set inside Hetzner's 10-rule limit

### DIFF
--- a/firewall.tf
+++ b/firewall.tf
@@ -30,6 +30,11 @@ locals {
     ) : []
   )
 
+  # Hetzner Robot's stateless firewall accepts at most 10 rules per direction.
+  # A POST with more is rejected in full, so the server ends up with no
+  # firewall rather than a truncated one.
+  robot_firewall_max_rules_per_direction = 10
+
   robot_firewall_base_curl_data = [
     "status=active",
     "whitelist_hos=true",
@@ -186,14 +191,6 @@ locals {
     ) :
     []
   )
-  bare_metal_firewall_kube_api_configured_ipv4_sources = [
-    for source in coalesce(local.firewall_kube_api_source, []) : source
-    if !strcontains(source, ":")
-  ]
-  bare_metal_firewall_kube_api_configured_ipv6_sources = [
-    for source in coalesce(local.firewall_kube_api_source, []) : source
-    if strcontains(source, ":")
-  ]
   bare_metal_firewall_talos_api_configured_ipv4_sources = [
     for source in coalesce(local.firewall_talos_api_source, []) : source
     if !strcontains(source, ":")
@@ -202,21 +199,10 @@ locals {
     for source in coalesce(local.firewall_talos_api_source, []) : source
     if strcontains(source, ":")
   ]
-  bare_metal_firewall_kube_api_sources = distinct(compact(concat(
-    local.bare_metal_firewall_ipv4_available ? local.bare_metal_firewall_kube_api_configured_ipv4_sources : local.bare_metal_firewall_kube_api_configured_ipv6_sources,
-    local.bare_metal_firewall_ipv4_available ? local.bare_metal_firewall_current_ipv4_sources : local.bare_metal_firewall_current_ipv6_sources
-  )))
   bare_metal_firewall_talos_api_sources = distinct(compact(concat(
     local.bare_metal_firewall_ipv4_available ? local.bare_metal_firewall_talos_api_configured_ipv4_sources : local.bare_metal_firewall_talos_api_configured_ipv6_sources,
     local.bare_metal_firewall_ipv4_available ? local.bare_metal_firewall_current_ipv4_sources : local.bare_metal_firewall_current_ipv6_sources
   )))
-  bare_metal_firewall_kube_api_ipv4_sources = [
-    for source in local.bare_metal_firewall_kube_api_sources : source
-    if !strcontains(source, ":")
-  ]
-  bare_metal_firewall_kube_api_ipv6_enabled = anytrue([
-    for source in local.bare_metal_firewall_kube_api_sources : strcontains(source, ":")
-  ])
   bare_metal_firewall_talos_api_ipv4_sources = [
     for source in local.bare_metal_firewall_talos_api_sources : source
     if !strcontains(source, ":")
@@ -327,30 +313,18 @@ locals {
         action     = "accept"
       },
     ],
-    [
-      for source_index, source in local.bare_metal_firewall_kube_api_ipv4_sources : {
-        name       = "Allow Kube API IPv4 ${source_index + 1}"
-        ip_version = "ipv4"
-        protocol   = "tcp"
-        dst_port   = tostring(local.kube_api_port)
-        tcp_flags  = null
-        src_ip     = source
-        dst_ip     = null
-        action     = "accept"
-      }
-    ],
-    local.bare_metal_firewall_kube_api_ipv6_enabled ? [
-      {
-        name       = "Allow Kube API IPv6"
-        ip_version = "ipv6"
-        protocol   = "tcp"
-        dst_port   = tostring(local.kube_api_port)
-        tcp_flags  = null
-        src_ip     = null
-        dst_ip     = null
-        action     = "accept"
-      },
-    ] : [],
+    # No Kube API rules here on purpose. Bare metal servers join as workers
+    # (see var.bare_metal_nodepools), so no kube-apiserver ever listens on
+    # them and a rule for local.kube_api_port can never match traffic.
+    #
+    # Emitting them is not just dead weight, it breaks the firewall: the
+    # Robot API accepts at most 10 rules per direction, and this block
+    # produced one rule per source in firewall_kube_api_source (which falls
+    # back to firewall_api_source). A cluster that allows its own and a
+    # second cluster's node IPs to the Kube API reaches that ceiling easily
+    # — 10 sources plus the two base rules and one Talos API rule is 13, and
+    # Robot rejects the whole set with 400 INVALID_INPUT invalid:["rules"].
+    # The bare metal node then never gets a firewall at all.
     [
       for source_index, source in local.bare_metal_firewall_talos_api_ipv4_sources : {
         name       = "Allow Talos API IPv4 ${source_index + 1}"
@@ -639,6 +613,21 @@ resource "terraform_data" "bare_metal_firewall" {
       ROBOT_FIREWALL_CURL_DATA = jsonencode(local.bare_metal_firewall_curl_data)
       ROBOT_USER               = var.hcloud_robot_user
       ROBOT_PASSWORD           = nonsensitive(var.hcloud_robot_password)
+    }
+  }
+
+  # The Robot API accepts at most 10 rules per direction and rejects a set
+  # that exceeds it as a whole, with 400 INVALID_INPUT invalid:["rules"] and
+  # no hint about which limit was hit. Fail here instead, while the operator
+  # can still see which list grew too long.
+  lifecycle {
+    precondition {
+      condition     = length(local.bare_metal_firewall_input_rules) <= local.robot_firewall_max_rules_per_direction
+      error_message = "Bare metal server ${each.value.number} would get ${length(local.bare_metal_firewall_input_rules)} Robot firewall input rules, but Hetzner Robot accepts at most ${local.robot_firewall_max_rules_per_direction} per direction. Every source in firewall_talos_api_source (which falls back to firewall_api_source) adds one rule; narrow that list or move sources into the private network."
+    }
+    precondition {
+      condition     = length(local.bare_metal_firewall_output_rules) <= local.robot_firewall_max_rules_per_direction
+      error_message = "Bare metal server ${each.value.number} would get ${length(local.bare_metal_firewall_output_rules)} Robot firewall output rules, but Hetzner Robot accepts at most ${local.robot_firewall_max_rules_per_direction} per direction. Reduce the outbound rules in firewall_extra_rules."
     }
   }
 

--- a/server.tf
+++ b/server.tf
@@ -306,6 +306,15 @@ resource "terraform_data" "bare_metal_server" {
       condition     = local.bare_metal_initialization_ssh_hosts[each.key] != ""
       error_message = "Bare metal initialization SSH host could not be determined for server ${each.value.number}."
     }
+
+    # One "Allow SSH IPv4 N" rule is emitted per source, and Robot rejects a
+    # rule set that exceeds its per-direction limit as a whole — with 400
+    # INVALID_INPUT invalid:["rules"] and no indication of the cause. Without
+    # this check the install aborts before the server is ever logged into.
+    precondition {
+      condition     = length(local.bare_metal_initialization_firewall_input_rules) <= local.robot_firewall_max_rules_per_direction
+      error_message = "Bare metal server ${each.value.number} would get ${length(local.bare_metal_initialization_firewall_input_rules)} Robot firewall input rules during initialization, but Hetzner Robot accepts at most ${local.robot_firewall_max_rules_per_direction} per direction. Each source in firewall_talos_api_source (which falls back to firewall_api_source) adds one SSH rule; set firewall_talos_api_source to just the address that runs OpenTofu."
+    }
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Problem

Adding a bare metal nodepool to a cluster that allows more than a handful of sources to its Kube API makes the Robot firewall step fail, and the server is left with **no firewall at all**:

```
Applying Robot firewall for bare metal server 3062817
Unexpected Robot API status while applying firewall for server 3062817: 400
{"error":{"status":400,"code":"INVALID_INPUT","message":"invalid input","invalid":["rules"]}}
```

Hetzner Robot's stateless firewall accepts **at most 10 rules per direction** and rejects a larger set as a whole. Measured against the live API on a GEX45:

| input rules | HTTP |
|---|---|
| 10 | 202 |
| 11 | 400 `invalid:["rules"]` |
| 13 | 400 `invalid:["rules"]` |

`bare_metal_firewall_input_rules` emits one rule per source in `firewall_kube_api_source` (which falls back to `firewall_api_source`). In a three-cluster setup where one cluster's nine node IPs are allowed so its ArgoCD can reach the other two, that is 9 + 1 operator IP = 10 Kube API rules, plus 2 base rules and 1 Talos API rule = **13**. The POST fails and the node never gets a firewall.

The error gives no hint about the cause — `invalid:["rules"]` is the same response you get for a malformed rule — so it is not obvious that a rule *count* is the problem.

## What this changes

**1. No Kube API rules for bare metal servers.** They can never match traffic: `var.bare_metal_nodepools` joins servers as workers, so no kube-apiserver ever listens on them. Removing them takes the rule set from 13 to 3 and removes the only part that grows with the size of an allow list. Three now-dead locals go with it.

**2. Preconditions that name the limit.** The initialization rule set has the same shape — one `Allow SSH IPv4 N` rule per source — and there the failure aborts the install *before the server is ever logged into*. That list is governed by `firewall_talos_api_source`, which an operator can legitimately narrow, so it keeps its per-source rules and gains a precondition instead. Both rule sets now fail with the limit, the actual count and the variable to narrow:

```
Bare metal server 3062817 would get 12 Robot firewall input rules during
initialization, but Hetzner Robot accepts at most 10 per direction. Each
source in firewall_talos_api_source (which falls back to firewall_api_source)
adds one SSH rule; set firewall_talos_api_source to just the address that
runs OpenTofu.
```

## Verification

- `tofu fmt -check` and `tofu validate` clean.
- Reproduced the failure on a GEX45 in HEL1 joined to a three-cluster setup (`firewall_api_source` = 1 operator IP + 9 node IPs): the module's 13-rule POST → `400 invalid:["rules"]`, repeatedly, on every apply.
- The 10-rule ceiling was measured directly against `robot-ws.your-server.de` with synthetic rule sets (table above), not inferred from documentation.
- A hand-built rule set of the shape this change produces — the two base rules plus operator-only Talos API, SSH and ICMP, six in total — was accepted (`202`, then `status: active`) on the same server, and the node runs on it.
- What I have **not** done yet is apply the patched module itself against Robot; that server is now managed with the hand-built set. Happy to run a full apply against the branch if that's wanted before merge.

## Note

`whitelist_hos` and the rule set also govern **vSwitch** traffic, not just the public uplink: a rule set without `Allow established TCP` made a healthy node go `NotReady`, because the kubelet's replies over the vSwitch were dropped. That is worth a line in the bare metal docs, and I'm happy to add it here or in a follow-up if you'd like it.
